### PR TITLE
Refactor weather agent to Click CLI, clean up dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ midojo-orchestrate --agent-url http://agent:8000 --suite weather
 - `app/routers/tasks.py` — FastAPI router with `/task/setup`, `/task/status`, `/task/prompt`, `/task/complete`, `/task/trace`, `/task/grade` endpoints.
 - `app/models.py` — `BenchmarkSession[Env]`, `SessionHolder`, `TraceEntry`, request/response models.
 - `grading.py` — `grade_task()` wrapping TaskSuite's `_check_task_result()` for utility and security evaluation. Generic over `TaskEnvironment`.
-- `serve.py` — combines MCP server (streamable HTTP at `/mcp`) and FastAPI control plane into one Starlette app. Requires `--suite` and `--real-mcp-url`.
+- `serve.py` — combines MCP server (streamable HTTP at `/mcp`) and FastAPI control plane into one FastAPI app. Requires `--suite` and `--real-mcp-url`.
 - `forwarding.py` — `MCPForwardingClient` (sync `call_tool` wrapping async MCP client), class-level singleton (`initialize()`, `get_instance()`, `is_initialized()`, `_reset()`). Initialized at startup from `--real-mcp-url`.
 - `orchestrator.py` — Click CLI that drives the benchmark matrix against external agents.
 - `agent_client.py` — `AgentClient` ABC with `SimpleHTTPAgentClient` and `A2AAgentClient` implementations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,12 @@ dependencies = [
     "pydantic>=2.7.1",
     "pyyaml>=6.0.1",
     "click>=8.1.7",
-    "python-dotenv>=1.0.0",
     "fastmcp",
     "fastapi>=0.115",
     "uvicorn>=0.34",
     "httpx>=0.28",
     "a2a-sdk>=1.0",
+    "openai>=1.0",
     "protobuf>=5.29,<6",
 ]
 
@@ -26,6 +26,7 @@ dev = [
     "pytest-asyncio>=0.24",
     "ruff>=0.3.0",
     "pyright>=1.1.362",
+    "python-dotenv[cli]>=1.0.0",
 ]
 
 [project.scripts]

--- a/src/midojo/suites/weather/agent.py
+++ b/src/midojo/suites/weather/agent.py
@@ -5,13 +5,21 @@ A minimal A2A-compliant agent that:
 2. Connects to midojo's MCP server for tool access
 3. Uses an OpenAI-compatible LLM (via LiteLLM) for reasoning
 4. Speaks the A2A JSON-RPC protocol for task handling
+
+Usage::
+
+    # With explicit flags
+    weather-agent --litellm-api-key=xxx --litellm-api-url=yyy --litellm-model=zzz
+
+    # With env vars (via dotenv run or exported)
+    dotenv run -- weather-agent
 """
 
 from __future__ import annotations
 
 import json
-import os
 
+import click
 import uvicorn
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
@@ -28,23 +36,12 @@ from a2a.types import (
     Part,
     Role,
 )
-from dotenv import load_dotenv
 from mcp.client.session import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 from openai import OpenAI
 from starlette.applications import Starlette
 
 from midojo.suites.weather import SYSTEM_MESSAGE
-
-load_dotenv()
-
-LITELLM_API_KEY = os.environ["LITELLM_API_KEY"]
-LITELLM_API_URL = os.environ["LITELLM_API_URL"]
-LITELLM_MODEL = os.environ["LITELLM_MODEL"]
-MCP_SERVER_URL = os.environ.get("MCP_SERVER_URL", "http://localhost:8080/mcp")
-AGENT_PORT = int(os.environ.get("AGENT_PORT", "8000"))
-
-llm = OpenAI(api_key=LITELLM_API_KEY, base_url=LITELLM_API_URL)
 
 
 def mcp_tools_to_openai(mcp_tools: list) -> list[dict]:
@@ -64,9 +61,9 @@ def mcp_tools_to_openai(mcp_tools: list) -> list[dict]:
     return openai_tools
 
 
-async def run_agent_loop(prompt: str) -> str:
+async def run_agent_loop(prompt: str, llm: OpenAI, model: str, mcp_server_url: str) -> str:
     """Connect to MCP, discover tools, run tool-use loop with LLM."""
-    async with streamablehttp_client(MCP_SERVER_URL) as (read_stream, write_stream, _):
+    async with streamablehttp_client(mcp_server_url) as (read_stream, write_stream, _):
         async with ClientSession(read_stream, write_stream) as session:
             await session.initialize()
 
@@ -80,7 +77,7 @@ async def run_agent_loop(prompt: str) -> str:
 
             for _ in range(10):
                 response = llm.chat.completions.create(
-                    model=LITELLM_MODEL,
+                    model=model,
                     messages=messages,
                     tools=openai_tools if openai_tools else None,
                 )
@@ -115,6 +112,11 @@ async def run_agent_loop(prompt: str) -> str:
 
 
 class WeatherAgentExecutor(AgentExecutor):
+    def __init__(self, llm: OpenAI, model: str, mcp_server_url: str) -> None:
+        self.llm = llm
+        self.model = model
+        self.mcp_server_url = mcp_server_url
+
     async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
         user_message = context.message
         prompt = ""
@@ -122,7 +124,7 @@ class WeatherAgentExecutor(AgentExecutor):
             prompt = user_message.parts[0].text
 
         print(f"Received prompt: {prompt[:100]}...")
-        response_text = await run_agent_loop(prompt)
+        response_text = await run_agent_loop(prompt, self.llm, self.model, self.mcp_server_url)
         print(f"Response: {response_text[:100]}...")
 
         await event_queue.enqueue_event(Message(role=Role.ROLE_AGENT, parts=[Part(text=response_text)]))
@@ -139,38 +141,49 @@ weather_skill = AgentSkill(
     examples=["What's the weather in New York?", "Which city is warmest?"],
 )
 
-agent_card = AgentCard(
-    name="Weather Agent",
-    description="A weather assistant that looks up current conditions using MCP tools.",
-    version="1.0.0",
-    supported_interfaces=[
-        AgentInterface(url=f"http://localhost:{AGENT_PORT}/", protocol_binding="JSONRPC"),
-    ],
-    default_input_modes=["text/plain"],
-    default_output_modes=["text/plain"],
-    capabilities=AgentCapabilities(streaming=True),
-    skills=[weather_skill],
-)
 
-request_handler = DefaultRequestHandler(
-    agent_executor=WeatherAgentExecutor(),
-    task_store=InMemoryTaskStore(),
-    agent_card=agent_card,
-)
+@click.command()
+@click.option("--host", default="127.0.0.1", help="Host to bind to.")
+@click.option("--port", default=8000, type=int, help="Port to bind to.", envvar="AGENT_PORT")
+@click.option("--mcp-server-url", default="http://localhost:8080/mcp", help="URL of the MCP server.", envvar="MCP_SERVER_URL")
+@click.option("--litellm-api-key", required=True, help="LiteLLM API key.", envvar="LITELLM_API_KEY")
+@click.option("--litellm-api-url", required=True, help="LiteLLM API URL.", envvar="LITELLM_API_URL")
+@click.option("--litellm-model", required=True, help="LiteLLM model name.", envvar="LITELLM_MODEL")
+def main(host: str, port: int, mcp_server_url: str, litellm_api_key: str, litellm_api_url: str, litellm_model: str) -> None:
+    llm = OpenAI(api_key=litellm_api_key, base_url=litellm_api_url)
 
-routes = []
-routes.extend(create_agent_card_routes(agent_card))
-routes.extend(create_jsonrpc_routes(request_handler, "/"))
+    executor = WeatherAgentExecutor(llm, litellm_model, mcp_server_url)
 
-app = Starlette(routes=routes)
+    agent_card = AgentCard(
+        name="Weather Agent",
+        description="A weather assistant that looks up current conditions using MCP tools.",
+        version="1.0.0",
+        supported_interfaces=[
+            AgentInterface(url=f"http://localhost:{port}/", protocol_binding="JSONRPC"),
+        ],
+        default_input_modes=["text/plain"],
+        default_output_modes=["text/plain"],
+        capabilities=AgentCapabilities(streaming=True),
+        skills=[weather_skill],
+    )
 
+    request_handler = DefaultRequestHandler(
+        agent_executor=executor,
+        task_store=InMemoryTaskStore(),
+        agent_card=agent_card,
+    )
 
-def main() -> None:
-    print(f"Starting A2A weather agent on port {AGENT_PORT}")
-    print(f"MCP server: {MCP_SERVER_URL}")
-    print(f"LLM model: {LITELLM_MODEL}")
-    print(f"Agent card: http://localhost:{AGENT_PORT}/.well-known/agent-card.json")
-    uvicorn.run(app, host="127.0.0.1", port=AGENT_PORT)
+    routes = []
+    routes.extend(create_agent_card_routes(agent_card))
+    routes.extend(create_jsonrpc_routes(request_handler, "/"))
+
+    app = Starlette(routes=routes)
+
+    print(f"Starting A2A weather agent on port {port}")
+    print(f"MCP server: {mcp_server_url}")
+    print(f"LLM model: {litellm_model}")
+    print(f"Agent card: http://localhost:{port}/.well-known/agent-card.json")
+    uvicorn.run(app, host=host, port=port)
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -1409,9 +1409,9 @@ dependencies = [
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "httpx" },
+    { name = "openai" },
     { name = "protobuf" },
     { name = "pydantic" },
-    { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "uvicorn" },
 ]
@@ -1421,6 +1421,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "python-dotenv", extra = ["cli"] },
     { name = "ruff" },
 ]
 
@@ -1432,12 +1433,13 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "fastmcp" },
     { name = "httpx", specifier = ">=0.28" },
+    { name = "openai", specifier = ">=1.0" },
     { name = "protobuf", specifier = ">=5.29,<6" },
     { name = "pydantic", specifier = ">=2.7.1" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.362" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.2" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
-    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "python-dotenv", extras = ["cli"], marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
     { name = "uvicorn", specifier = ">=0.34" },
@@ -2006,6 +2008,11 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "click" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replace `load_dotenv` + module-level env vars in `weather-agent` with a Click CLI that accepts flags or env vars (via `envvar=`)
- Thread LLM config through `WeatherAgentExecutor` instead of module-level globals
- Add missing `openai` dependency to main deps
- Move `python-dotenv[cli]` from main deps to dev deps (use `dotenv run -- weather-agent` from the shell)
- Fix CLAUDE.md: Starlette → FastAPI

## Test plan
- [x] `uv run python -m pytest tests/ -v` — 34 passed
- [x] `weather-agent --help` — shows new CLI options
- [x] Agent starts and serves agent card at `/.well-known/agent-card.json`
- [x] `midojo-orchestrate --protocol a2a` — 100% utility against live agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)