### PR TITLE
Fix attack execution in orchestrator via ServerCandidatesMixin

### DIFF
--- a/src/midojo/attack.py
+++ b/src/midojo/attack.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from agentdojo.attacks.attack_registry import ATTACKS
+from agentdojo.attacks.base_attacks import BaseAttack
+from agentdojo.base_tasks import BaseUserTask
+from agentdojo.task_suite.task_suite import TaskSuite
+
+
+class _NullPipeline:
+    """Dummy pipeline for external agents that don't have an AgentDojo pipeline.
+
+    Satisfies get_model_name_from_pipeline(), which falls back to "AI assistant"
+    when no model name matches.
+
+    TODO: propose upstream PR to accept lightweight metadata (e.g. model name)
+    instead of requiring a full BasePipelineElement just to personalize attacks.
+    """
+
+    name = "external-agent"
+
+
+class ServerCandidatesMixin:
+    """Overrides injection candidate discovery to use pre-fetched server data.
+
+    AgentDojo's BaseAttack.get_injection_candidates runs tool functions locally,
+    which fails for midojo's forwarding tools (they need the server process).
+    This mixin uses candidates fetched from the server's /admin/injection-candidates
+    endpoint instead.
+    """
+
+    _server_candidates: dict[str, list[str]]
+
+    def __init__(self, task_suite: TaskSuite, candidates: dict[str, list[str]], **kwargs):
+        self._server_candidates = candidates
+        super().__init__(task_suite, _NullPipeline(), **kwargs)
+
+    def get_injection_candidates(self, user_task: BaseUserTask) -> list[str]:
+        return self._server_candidates[user_task.ID]
+
+
+def create_attack(attack_name: str, suite: TaskSuite, candidates: dict[str, list[str]]) -> BaseAttack:
+    """Create an attack that uses server-fetched injection candidates."""
+    base_cls = ATTACKS[attack_name]
+    patched_cls = type(f"MiDojo{base_cls.__name__}", (ServerCandidatesMixin, base_cls), {})
+    return patched_cls(suite, candidates)

--- a/src/midojo/orchestrator.py
+++ b/src/midojo/orchestrator.py
@@ -7,11 +7,11 @@ from pathlib import Path
 
 import click
 import httpx
-from agentdojo.attacks.attack_registry import load_attack
 from agentdojo.benchmark import SuiteResults
 from agentdojo.task_suite.task_suite import TaskSuite
 
 from midojo.agent_client import A2AAgentClient, AgentClient, SimpleHTTPAgentClient
+from midojo.attack import create_attack
 from midojo.suites import get_suite
 
 
@@ -74,7 +74,11 @@ async def run_benchmark(
             utility_results[(ut_id, "")] = result["utility"]
             click.echo(f"  utility={result['utility']}")
     else:
-        attack = load_attack(attack_name, suite, None)  # type: ignore
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.get(f"{control_url}/admin/injection-candidates")
+            resp.raise_for_status()
+            candidates = resp.json()
+        attack = create_attack(attack_name, suite, candidates)
         for ut_id in user_tasks_to_run:
             user_task = suite.user_tasks[ut_id]
             for it_id in injection_tasks_to_run:


### PR DESCRIPTION
## Summary
- Add `ServerCandidatesMixin` in new `attack.py` — overrides `get_injection_candidates` to use data fetched from the server instead of running tool functions locally (which crashes because forwarding tools need the server process)
- `_NullPipeline` dummy satisfies attacks that call `get_model_name_from_pipeline` in `__init__` (e.g. `important_instructions`), falling back to "AI assistant"
- `create_attack()` dynamically composes the mixin with any AgentDojo attack class via `type()`
- Orchestrator fetches `GET /admin/injection-candidates` before the attack loop

## Test plan
- [x] `uv run python -m pytest tests/ -v` — 34 passed
- [x] `midojo-orchestrate --attack direct` — runs end-to-end, no crash
- [x] `midojo-orchestrate --attack important_instructions` — runs end-to-end, no crash (previously failed with `AttributeError: 'NoneType' object has no attribute 'name'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)