### PR TITLE
Separate API schemas from state models, unify FunctionCallRecord

### DIFF
--- a/src/midojo/app/dependencies.py
+++ b/src/midojo/app/dependencies.py
@@ -5,7 +5,7 @@ from fastapi import HTTPException, status
 from midojo.yaml_task_suite import YAMLTaskSuite
 
 from . import state
-from .models import Evaluation, Run
+from .state import Evaluation, Run
 
 
 def get_suite() -> YAMLTaskSuite:

--- a/src/midojo/app/models.py
+++ b/src/midojo/app/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from agentdojo.functions_runtime import TaskEnvironment
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, SerializeAsAny
 
 
 # --- Run / Evaluation request/response models ---
@@ -57,8 +57,8 @@ class FunctionCallRecord(BaseModel):
     result: str
     error: str | None
     timestamp: str
-    pre_environment: TaskEnvironment
-    post_environment: TaskEnvironment
+    pre_environment: SerializeAsAny[TaskEnvironment]
+    post_environment: SerializeAsAny[TaskEnvironment]
 
 
 class EvaluationResponse(BaseModel):

--- a/src/midojo/app/models.py
+++ b/src/midojo/app/models.py
@@ -1,18 +1,7 @@
 from __future__ import annotations
 
-import uuid
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
-from typing import Generic, TypeVar
-
-from agentdojo.functions_runtime import FunctionsRuntime, TaskEnvironment
-from pydantic import BaseModel
-
-Env = TypeVar("Env", bound=TaskEnvironment)
-
-
-def _new_id() -> str:
-    return uuid.uuid4().hex[:8]
+from agentdojo.functions_runtime import TaskEnvironment
+from pydantic import BaseModel, ConfigDict
 
 
 # --- Run / Evaluation request/response models ---
@@ -57,17 +46,19 @@ class RunResponse(BaseModel):
     evaluations: list[EvaluationSummary]
 
 
-class FunctionCallSummary(BaseModel):
+class FunctionCallRecord(BaseModel):
+    """A recorded function call execution, distinct from agentdojo's
+    FunctionCall which represents just the intent (function + args)."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     function: str
     args: dict
     result: str
     error: str | None
     timestamp: str
-
-
-class FunctionCallResponse(FunctionCallSummary):
-    pre_environment: dict
-    post_environment: dict
+    pre_environment: TaskEnvironment
+    post_environment: TaskEnvironment
 
 
 class EvaluationResponse(BaseModel):
@@ -78,7 +69,7 @@ class EvaluationResponse(BaseModel):
     utility: bool | None
     security: bool | None
     model_output: str | None
-    function_calls: list[FunctionCallSummary]
+    function_calls: list[FunctionCallRecord]
 
 
 # --- Suite / task / tool response models ---
@@ -129,43 +120,3 @@ class ToolInfoResponse(BaseModel):
     name: str
     description: str
     parameters: dict
-
-
-# --- Internal state ---
-
-
-@dataclass
-class FunctionCallRecord:
-    """A recorded function call execution, distinct from agentdojo's FunctionCall which represents just the intent (function + args)."""
-
-    function: str
-    args: dict
-    result: str
-    error: str | None
-    timestamp: str
-    pre_environment: dict = field(default_factory=dict)
-    post_environment: dict = field(default_factory=dict)
-
-
-@dataclass
-class Evaluation(Generic[Env]):
-    id: str
-    user_task_id: str
-    injection_task_id: str | None
-    pre_environment: Env
-    environment: Env
-    runtime: FunctionsRuntime
-    function_calls: list[FunctionCallRecord] = field(default_factory=list)
-    model_output: str | None = None
-    completed: bool = False
-    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
-    active_injections: dict[str, str] = field(default_factory=dict)
-    utility: bool | None = None
-    security: bool | None = None
-
-
-@dataclass
-class Run:
-    id: str
-    evaluations: dict[str, Evaluation] = field(default_factory=dict)
-    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())

--- a/src/midojo/app/routers/mcp.py
+++ b/src/midojo/app/routers/mcp.py
@@ -23,7 +23,7 @@ def _make_tool_handler(func: Function):
         if evaluation is None:
             raise ToolError("No evaluation in progress. Create one via POST /runs/{run_id}/evaluations first.")
 
-        pre_env = evaluation.environment.model_dump()
+        pre_env = evaluation.environment.model_copy(deep=True)
 
         if MCPForwardingClient.is_initialized():
             result, error = await asyncio.to_thread(
@@ -33,7 +33,7 @@ def _make_tool_handler(func: Function):
             result, error = evaluation.runtime.run_function(evaluation.environment, func.name, kwargs)
 
         result_str = tool_result_to_str(result) if result is not None else ""
-        post_env = evaluation.environment.model_dump()
+        post_env = evaluation.environment.model_copy(deep=True)
 
         evaluation.function_calls.append(
             FunctionCallRecord(

--- a/src/midojo/app/routers/runs.py
+++ b/src/midojo/app/routers/runs.py
@@ -16,16 +16,13 @@ from ..models import (
     CreateEvaluationRequest,
     CreateEvaluationResponse,
     CreateRunResponse,
-    Evaluation,
     EvaluationResponse,
     EvaluationSummary,
-    FunctionCallResponse,
-    FunctionCallSummary,
+    FunctionCallRecord,
     GradeResponse,
-    Run,
     RunResponse,
-    _new_id,
 )
+from ..state import Evaluation, Run, _new_id
 
 router = APIRouter(prefix="/runs")
 
@@ -89,7 +86,15 @@ def create_evaluation(
     return CreateEvaluationResponse(id=evaluation.id, prompt=prompt)
 
 
-@router.get("/{run_id}/evaluations/{eval_id}", response_model=EvaluationResponse, status_code=status.HTTP_200_OK)
+_FC_ENV_FIELDS = {"pre_environment", "post_environment"}
+
+
+@router.get(
+    "/{run_id}/evaluations/{eval_id}",
+    response_model=EvaluationResponse,
+    response_model_exclude={"function_calls": {"__all__": _FC_ENV_FIELDS}},
+    status_code=status.HTTP_200_OK,
+)
 def retrieve_evaluation(evaluation: Annotated[Evaluation, Depends(get_evaluation)]):
     return EvaluationResponse(
         id=evaluation.id,
@@ -99,12 +104,7 @@ def retrieve_evaluation(evaluation: Annotated[Evaluation, Depends(get_evaluation
         utility=evaluation.utility,
         security=evaluation.security,
         model_output=evaluation.model_output,
-        function_calls=[
-            FunctionCallSummary(
-                function=fc.function, args=fc.args, result=fc.result, error=fc.error, timestamp=fc.timestamp
-            )
-            for fc in evaluation.function_calls
-        ],
+        function_calls=evaluation.function_calls,
     )
 
 
@@ -163,33 +163,20 @@ def register_environment_update_route(env_type: type) -> None:
 
 @router.get(
     "/{run_id}/evaluations/{eval_id}/function-calls",
-    response_model=list[FunctionCallSummary],
+    response_model=list[FunctionCallRecord],
+    response_model_exclude={"__all__": _FC_ENV_FIELDS},
     status_code=status.HTTP_200_OK,
 )
-def list_function_calls(evaluation: Annotated[Evaluation, Depends(get_evaluation)]) -> list[FunctionCallSummary]:
-    return [
-        FunctionCallSummary(
-            function=fc.function, args=fc.args, result=fc.result, error=fc.error, timestamp=fc.timestamp
-        )
-        for fc in evaluation.function_calls
-    ]
+def list_function_calls(evaluation: Annotated[Evaluation, Depends(get_evaluation)]) -> list[FunctionCallRecord]:
+    return evaluation.function_calls
 
 
 @router.get(
     "/{run_id}/evaluations/{eval_id}/function-calls/{idx}",
-    response_model=FunctionCallResponse,
+    response_model=FunctionCallRecord,
     status_code=status.HTTP_200_OK,
 )
-def get_function_call(idx: int, evaluation: Annotated[Evaluation, Depends(get_evaluation)]) -> FunctionCallResponse:
+def get_function_call(idx: int, evaluation: Annotated[Evaluation, Depends(get_evaluation)]) -> FunctionCallRecord:
     if idx < 0 or idx >= len(evaluation.function_calls):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Function call index out of range: {idx}")
-    fc = evaluation.function_calls[idx]
-    return FunctionCallResponse(
-        function=fc.function,
-        args=fc.args,
-        result=fc.result,
-        error=fc.error,
-        timestamp=fc.timestamp,
-        pre_environment=fc.pre_environment,
-        post_environment=fc.post_environment,
-    )
+    return evaluation.function_calls[idx]

--- a/src/midojo/app/state.py
+++ b/src/midojo/app/state.py
@@ -6,9 +6,54 @@ this layer later.
 
 from __future__ import annotations
 
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Generic, TypeVar
+
+from agentdojo.functions_runtime import FunctionsRuntime, TaskEnvironment
+from pydantic import BaseModel, ConfigDict, Field
+
 from midojo.yaml_task_suite import YAMLTaskSuite
 
-from .models import Evaluation, Run
+from .models import FunctionCallRecord
+
+Env = TypeVar("Env", bound=TaskEnvironment)
+
+
+def _new_id() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+# --- State models ---
+
+
+@dataclass
+class Evaluation(Generic[Env]):
+    id: str
+    user_task_id: str
+    injection_task_id: str | None
+    pre_environment: Env
+    environment: Env
+    runtime: FunctionsRuntime
+    function_calls: list[FunctionCallRecord] = field(default_factory=list)
+    model_output: str | None = None
+    completed: bool = False
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    active_injections: dict[str, str] = field(default_factory=dict)
+    utility: bool | None = None
+    security: bool | None = None
+
+
+class Run(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    id: str
+    evaluations: dict[str, Evaluation] = {}
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+# --- Module-level state ---
 
 suite: YAMLTaskSuite = None  # type: ignore[assignment]
 runs: dict[str, Run] = {}

--- a/src/midojo/app/state.py
+++ b/src/midojo/app/state.py
@@ -9,16 +9,12 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Generic, TypeVar
-
 from agentdojo.functions_runtime import FunctionsRuntime, TaskEnvironment
 from pydantic import BaseModel, ConfigDict, Field
 
 from midojo.yaml_task_suite import YAMLTaskSuite
 
 from .models import FunctionCallRecord
-
-Env = TypeVar("Env", bound=TaskEnvironment)
 
 
 def _new_id() -> str:
@@ -29,12 +25,12 @@ def _new_id() -> str:
 
 
 @dataclass
-class Evaluation(Generic[Env]):
+class Evaluation:
     id: str
     user_task_id: str
     injection_task_id: str | None
-    pre_environment: Env
-    environment: Env
+    pre_environment: TaskEnvironment
+    environment: TaskEnvironment
     runtime: FunctionsRuntime
     function_calls: list[FunctionCallRecord] = field(default_factory=list)
     model_output: str | None = None

--- a/src/midojo/app/state.py
+++ b/src/midojo/app/state.py
@@ -26,6 +26,8 @@ def _new_id() -> str:
 
 @dataclass
 class Evaluation:
+    """A single task execution within a Run. Captures the environment before and after tool execution, the function call trace, and grading results."""
+
     id: str
     user_task_id: str
     injection_task_id: str | None

--- a/tests/test_control_api.py
+++ b/tests/test_control_api.py
@@ -133,9 +133,9 @@ def test_trace_recording():
     eval_id = eval_data["id"]
 
     evaluation = state.current_eval
-    pre_env = evaluation.environment.model_dump()
+    pre_env = evaluation.environment.model_copy(deep=True)
     evaluation.runtime.run_function(evaluation.environment, "get_weather", {"city": "New York"})
-    post_env = evaluation.environment.model_dump()
+    post_env = evaluation.environment.model_copy(deep=True)
     evaluation.function_calls.append(
         FunctionCallRecord(
             function="get_weather",
@@ -168,9 +168,9 @@ def test_full_task_lifecycle():
     eval_id = eval_data["id"]
 
     evaluation = state.current_eval
-    pre_env = evaluation.environment.model_dump()
+    pre_env = evaluation.environment.model_copy(deep=True)
     result, _ = evaluation.runtime.run_function(evaluation.environment, "get_weather", {"city": "New York"})
-    post_env = evaluation.environment.model_dump()
+    post_env = evaluation.environment.model_copy(deep=True)
     evaluation.function_calls.append(
         FunctionCallRecord(
             function="get_weather",

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -5,9 +5,12 @@ from midojo.grading import grade_task
 from midojo.suites.weather import task_suite
 
 
-def _make_function_calls(*calls: tuple[str, dict]) -> list[FunctionCallRecord]:
+def _make_function_calls(env, *calls: tuple[str, dict]) -> list[FunctionCallRecord]:
     return [
-        FunctionCallRecord(function=name, args=args, result="", error=None, timestamp="2024-01-01T00:00:00Z")
+        FunctionCallRecord(
+            function=name, args=args, result="", error=None, timestamp="2024-01-01T00:00:00Z",
+            pre_environment=env, post_environment=env,
+        )
         for name, args in calls
     ]
 
@@ -23,7 +26,7 @@ def test_utility_pass():
         model_output="The weather in New York is 72°F and sunny.",
         pre_environment=pre_env,
         post_environment=env,
-        function_calls=_make_function_calls(("get_weather", {"city": "New York"})),
+        function_calls=_make_function_calls(env, ("get_weather", {"city": "New York"})),
     )
     assert result["utility"] is True
     assert result["security"] is False
@@ -56,7 +59,7 @@ def test_security_attack_not_executed():
         model_output="The weather in New York is 72°F and sunny.",
         pre_environment=pre_env,
         post_environment=env,
-        function_calls=_make_function_calls(("get_weather", {"city": "New York"})),
+        function_calls=_make_function_calls(env, ("get_weather", {"city": "New York"})),
     )
     assert result["utility"] is True
     assert result["security"] is False
@@ -77,6 +80,7 @@ def test_security_attack_executed():
         pre_environment=pre_env,
         post_environment=env,
         function_calls=_make_function_calls(
+            env,
             ("get_weather", {"city": "New York"}),
             ("send_weather_alert", {"city": "Chicago", "message": "Severe tornado warning"}),
         ),

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 from agentdojo.functions_runtime import FunctionsRuntime
 
 from midojo.app import state
-from midojo.app.models import Evaluation
+from midojo.app.state import Evaluation
 from midojo.app.routers.mcp import create_mcp_server
 from midojo.forwarding import MCPForwardingClient
 from midojo.suites.weather import task_suite
@@ -86,8 +86,8 @@ def test_tool_call_records_trace():
     assert fcs[1].args == {"city": "Chicago"}
     assert fcs[0].error is None
     assert fcs[1].error is None
-    assert "cities" in fcs[0].pre_environment
-    assert "cities" in fcs[0].post_environment
+    assert hasattr(fcs[0].pre_environment, "cities")
+    assert hasattr(fcs[0].post_environment, "cities")
 
 
 def test_tool_call_without_session():


### PR DESCRIPTION
## Summary
- Move `Evaluation` and `Run` to `state.py` as domain/state models (future DB layer); `models.py` is now purely API schemas
- Convert `Run` and `FunctionCallRecord` from dataclasses to Pydantic BaseModel
- Unify `FunctionCallRecord`, `FunctionCallSummary`, and `FunctionCallResponse` into a single `FunctionCallRecord` model; list endpoints use `response_model_exclude` to omit environment snapshots
- Store per-call `pre_environment`/`post_environment` as `TaskEnvironment` instead of `dict`

## Test plan
- [x] All 94 existing tests pass
- [x] Run the app and hit function call list/detail endpoints to verify environment fields are excluded/included correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)