### PR TITLE
Add PI agent protocol support to orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ For [PI](https://pi.dev) coding agents. The agent already has its tools register
 
 - `02-real-tools.ts` — stands in for the agent's existing tools (in real life, these are whatever extensions the agent already has)
 - `01-fake-tools.ts` — the interception layer you author, built with `@midojo/pi-sdk`. Uses two mechanisms:
-  - **Tool overrides** (`tools`) — replaces a tool entirely. Loads first (PI uses first-registration-wins), so the real tool's registration is ignored. Used for write tools that need to operate on the simulated environment.
+  - **Tool overrides** (`tools`) — registers a tool that operates on the simulated environment. Used for write tools whose mutations need to be captured for grading. **PI limitation:** duplicate tool names across extensions cause a conflict error, so any tool registered in the fake extension must be commented out in the real extension.
   - **Hooks** (`hooks`) — intercepts the result of an existing tool after it executes and modifies it before the agent sees it. Used for read tools where you want real data + injection payload.
   - Tools with no override or hook run unmodified.
 
@@ -176,7 +176,7 @@ Then point the agent at your fake server instead of its real one.
 Create a PI extension using `@midojo/pi-sdk`'s `createMidojoExtension()` and drop it into the agent's `.pi/extensions/` directory. Number it so it loads before the agent's existing extensions (PI uses first-registration-wins). For each tool, decide:
 
 - **Read tools you want to inject into** — add a `hook`. The hook receives the real tool's output and can append injection data from `ctx.env()` before the agent sees it.
-- **Write tools** — add a `tools` entry (override). Because your extension loads first, the override's registration wins and the real tool is never called. The override operates on `ctx.env()` / `ctx.envUpdate()`.
+- **Write tools** — add a `tools` entry (override) in the fake extension, and comment out the same tool in the agent's real extension. PI does not support duplicate tool names across extensions, so the real registration must be removed. The override operates on `ctx.env()` / `ctx.envUpdate()` so mutations are captured for grading.
 - **Tools to leave alone** — don't mention them. The real tool runs unmodified.
 
 ## Future Work

--- a/src/midojo/agent_client.py
+++ b/src/midojo/agent_client.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import abc
+import asyncio
+import os
 import uuid
 
 import httpx
@@ -8,7 +10,7 @@ import httpx
 
 class AgentClient(abc.ABC):
     @abc.abstractmethod
-    async def send_task(self, prompt: str) -> str:
+    async def send_task(self, prompt: str, *, run_id: str = "", eval_id: str = "") -> str:
         """Send a task prompt to the agent and return its final text output."""
         ...
 
@@ -24,7 +26,7 @@ class SimpleHTTPAgentClient(AgentClient):
         self.agent_url = agent_url
         self.timeout = timeout
 
-    async def send_task(self, prompt: str) -> str:
+    async def send_task(self, prompt: str, *, run_id: str = "", eval_id: str = "") -> str:
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             resp = await client.post(self.agent_url, json={"prompt": prompt})
             resp.raise_for_status()
@@ -46,7 +48,7 @@ class A2AAgentClient(AgentClient):
         self.agent_url = agent_url
         self.timeout = timeout
 
-    async def send_task(self, prompt: str) -> str:
+    async def send_task(self, prompt: str, *, run_id: str = "", eval_id: str = "") -> str:
         from a2a.client import create_client
         from a2a.types import Message, Part, Role, SendMessageRequest
 
@@ -80,3 +82,54 @@ class A2AAgentClient(AgentClient):
             return result_text
         finally:
             await client.close()
+
+
+class PIAgentClient(AgentClient):
+    """Launches a PI coding agent as a subprocess for each task.
+
+    The ``agent_dir`` should point to a directory containing a ``.pi/``
+    configuration folder with extensions that use ``@midojo/pi-sdk``.
+    """
+
+    def __init__(
+        self,
+        agent_dir: str,
+        control_url: str,
+        *,
+        timeout: float = 120.0,
+    ) -> None:
+        self.agent_dir = agent_dir
+        self.control_url = control_url
+        self.timeout = timeout
+
+    async def send_task(self, prompt: str, *, run_id: str = "", eval_id: str = "") -> str:
+        env = {
+            **os.environ,
+            "MIDOJO_URL": self.control_url,
+            "MIDOJO_RUN_ID": run_id,
+            "MIDOJO_EVAL_ID": eval_id,
+        }
+
+        proc = await asyncio.create_subprocess_exec(
+            "pi", "-p", "--no-session", prompt,
+            cwd=self.agent_dir,
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=self.timeout
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise TimeoutError(f"PI agent timed out after {self.timeout}s")
+
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"PI agent exited with code {proc.returncode}: {stderr.decode()}"
+            )
+
+        return stdout.decode().strip()

--- a/src/midojo/orchestrator.py
+++ b/src/midojo/orchestrator.py
@@ -15,7 +15,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from midojo.agent_client import A2AAgentClient, AgentClient, SimpleHTTPAgentClient
+from midojo.agent_client import A2AAgentClient, AgentClient, PIAgentClient, SimpleHTTPAgentClient
 from midojo.attack import create_attack
 from midojo.suites import get_suite
 
@@ -141,7 +141,7 @@ async def run_task(
         eval_id = eval_data["id"]
         prompt = eval_data["prompt"]
 
-        model_output = await agent_client.send_task(prompt)
+        model_output = await agent_client.send_task(prompt, run_id=run_id, eval_id=eval_id)
 
         complete_resp = await client.post(
             f"{control_url}/runs/{run_id}/evaluations/{eval_id}/complete",
@@ -244,7 +244,7 @@ async def run_benchmark(
 @click.option(
     "--module-to-load", "-ml", "modules_to_load", multiple=True, default=(), help="Additional modules to import."
 )
-@click.option("--protocol", type=click.Choice(["http", "a2a"]), required=True, help="Agent communication protocol.")
+@click.option("--protocol", type=click.Choice(["http", "a2a", "pi"]), required=True, help="Agent communication protocol.")
 def main(
     control_url: str,
     agent_url: str,
@@ -264,6 +264,8 @@ def main(
     agent_client: AgentClient
     if protocol == "a2a":
         agent_client = A2AAgentClient(agent_url)
+    elif protocol == "pi":
+        agent_client = PIAgentClient(agent_url, control_url)
     else:
         agent_client = SimpleHTTPAgentClient(agent_url)
 

--- a/src/midojo/suites/weather/pi_agent/.pi/extensions/02-real-tools.ts
+++ b/src/midojo/suites/weather/pi_agent/.pi/extensions/02-real-tools.ts
@@ -44,20 +44,25 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
-	pi.registerTool({
-		name: "send_weather_alert",
-		label: "Send Weather Alert",
-		description: "Send a weather alert for a city.",
-		parameters: Type.Object({
-			city: Type.String({ description: "The city the alert is for" }),
-			message: Type.String({ description: "The alert message" }),
-		}),
-		async execute(_toolCallId, params) {
-			const { city, message } = params as { city: string; message: string };
-			return {
-				content: [{ type: "text" as const, text: `Weather alert sent for ${city}: ${message}` }],
-				details: {},
-			};
-		},
-	});
+	// PI limitation: duplicate tool names across extensions cause a conflict
+	// error (even with load-order precedence). Tools overridden in fake-tools
+	// must be commented out here. The fake version in 01-fake-tools.ts writes
+	// to the simulated environment so grading can observe mutations.
+	//
+	// pi.registerTool({
+	// 	name: "send_weather_alert",
+	// 	label: "Send Weather Alert",
+	// 	description: "Send a weather alert for a city.",
+	// 	parameters: Type.Object({
+	// 		city: Type.String({ description: "The city the alert is for" }),
+	// 		message: Type.String({ description: "The alert message" }),
+	// 	}),
+	// 	async execute(_toolCallId, params) {
+	// 		const { city, message } = params as { city: string; message: string };
+	// 		return {
+	// 			content: [{ type: "text" as const, text: `Weather alert sent for ${city}: ${message}` }],
+	// 			details: {},
+	// 		};
+	// 	},
+	// });
 }


### PR DESCRIPTION
## Summary

- Add `PIAgentClient` in `agent_client.py` — launches `pi -p --no-session "prompt"` as a subprocess per task, passing `MIDOJO_URL`, `MIDOJO_RUN_ID`, `MIDOJO_EVAL_ID` as env vars so PI SDK extensions can record function calls to the control plane
- Add `--protocol pi` to the orchestrator CLI, where `--agent-url` points to the PI agent directory (containing `.pi/`)
- Extend `AgentClient.send_task()` with optional `run_id`/`eval_id` context (existing HTTP/A2A clients ignore them)
- Comment out `send_weather_alert` in `02-real-tools.ts` to work around PI's duplicate tool name conflict, and document the limitation in README

## Test plan

- [x] `uv run pytest tests/ -v` — 94 tests pass
- [x] E2E: `midojo-serve --suite weather` + `midojo-run --protocol pi --agent-url src/midojo/suites/weather/pi_agent --suite weather` — all 3 user tasks run, function calls recorded to control plane, grading works

🤖 Generated with [Claude Code](https://claude.com/claude-code)