### PR TITLE
Improve orchestrator UX: display run/eval IDs, fix relative PI agent paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,18 @@ midojo-run \
     --attack direct
 ```
 
-`--protocol` is required: use `a2a` for A2A agents or `http` for agents exposing a simple `POST {"prompt": "..."}` endpoint.
+`--protocol` is required: use `a2a` for A2A agents, `http` for agents exposing a simple `POST {"prompt": "..."}` endpoint, or `pi` for [PI](https://pi.dev) coding agents.
+
+#### Running with a PI agent
+
+For PI agents, `--agent-url` is a path to the directory containing the `.pi/` configuration (not a URL). The PI agent's LLM credentials are typically configured via environment variables referenced in `.pi/auth.json` — use `uv run --env-file .env` to load them:
+
+```bash
+uv run --env-file .env midojo-run \
+    --agent-url src/midojo/suites/weather/pi_agent \
+    --protocol pi \
+    --suite weather
+```
 
 ### Results
 

--- a/src/midojo/agent_client.py
+++ b/src/midojo/agent_client.py
@@ -98,7 +98,7 @@ class PIAgentClient(AgentClient):
         *,
         timeout: float = 120.0,
     ) -> None:
-        self.agent_dir = agent_dir
+        self.agent_dir = os.path.abspath(agent_dir)
         self.control_url = control_url
         self.timeout = timeout
 

--- a/src/midojo/orchestrator.py
+++ b/src/midojo/orchestrator.py
@@ -151,7 +151,9 @@ async def run_task(
 
         grade_resp = await client.post(f"{control_url}/runs/{run_id}/evaluations/{eval_id}/grade")
         grade_resp.raise_for_status()
-        return grade_resp.json()
+        result = grade_resp.json()
+        result["eval_id"] = eval_id
+        return result
 
 
 async def run_benchmark(
@@ -173,6 +175,7 @@ async def run_benchmark(
     _print_banner(suite_name, suite_info, attack_name, agent_url, protocol, user_tasks_to_run, injection_tasks_to_run)
 
     run_id = await _create_run(control_url)
+    console.print(f"  [dim]run[/dim] [cyan]{run_id}[/cyan]\n")
 
     utility_results: dict[TaskPair, bool] = {}
     security_results: dict[TaskPair, bool] = {}
@@ -182,7 +185,7 @@ async def run_benchmark(
             console.print(f"  Running [bold]{ut_id}[/bold] ...", end=" ")
             result = await run_task(control_url, agent_client, run_id, ut_id, None, {})
             utility_results[TaskPair(ut_id, "")] = result["utility"]
-            console.print(_utility(result["utility"]))
+            console.print(_utility(result["utility"]), Text(f"  eval {result['eval_id']}", style="dim"))
     else:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(f"{control_url}/tasks/injection-candidates")
@@ -198,14 +201,14 @@ async def run_benchmark(
                     console.print(f"  Running [bold]{ut_id}[/bold] x [bold]{it_id}[/bold] ...", end=" ")
                     result = await run_task(control_url, agent_client, run_id, ut_id, None, {})
                     utility_results[TaskPair(ut_id, it_id)] = result["utility"]
-                    console.print(_utility(result["utility"]), " | ", Text("N/A (not injectable)", style="dim"))
+                    console.print(_utility(result["utility"]), " | ", Text("N/A (not injectable)", style="dim"), Text(f"  eval {result['eval_id']}", style="dim"))
                 else:
                     console.print(f"  Running [bold]{ut_id}[/bold] x [bold]{it_id}[/bold] ...", end=" ")
                     injections = attack.attack(user_task, injection_task)
                     result = await run_task(control_url, agent_client, run_id, ut_id, it_id, injections)
                     utility_results[TaskPair(ut_id, it_id)] = result["utility"]
                     security_results[TaskPair(ut_id, it_id)] = result["security"]
-                    console.print(_utility(result["utility"]), " | ", _security(result["security"]))
+                    console.print(_utility(result["utility"]), " | ", _security(result["security"]), Text(f"  eval {result['eval_id']}", style="dim"))
 
     console.print()
 


### PR DESCRIPTION
## Summary

- Resolve `PIAgentClient.agent_dir` to absolute path so relative `--agent-url` works
- Display run ID after the banner and eval ID on each task progress line
- Document PI agent workflow with `uv run --env-file .env` in README

## Test plan

- [x] `uv run pytest tests/ -v` — 94 tests pass
- [x] E2E: `uv run --env-file .env midojo-run --agent-url src/midojo/suites/weather/pi_agent --protocol pi --suite weather` — all 3 user tasks run, IDs displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)