### PR TITLE
Detect injection reachability post-hoc from function-call results

### DIFF
--- a/src/midojo/attack.py
+++ b/src/midojo/attack.py
@@ -19,27 +19,25 @@ class _NullPipeline:
     name = "external-agent"
 
 
-class ServerCandidatesMixin:
-    """Overrides injection candidate discovery to use pre-fetched server data.
+class _AllVectorsMixin:
+    """Returns all injection vectors as candidates for every user task.
 
-    AgentDojo's BaseAttack.get_injection_candidates runs tool functions locally,
-    which fails for midojo's forwarding tools (they need the server process).
-    This mixin uses candidates fetched from the server's /tasks/injection-candidates
-    endpoint instead.
+    The orchestrator determines reachability post-hoc by checking whether
+    the attack payload appeared in any recorded function-call result.
     """
 
-    _server_candidates: dict[str, list[str]]
+    _all_vectors: list[str]
 
-    def __init__(self, task_suite: YAMLTaskSuite, candidates: dict[str, list[str]], **kwargs):
-        self._server_candidates = candidates
+    def __init__(self, task_suite: YAMLTaskSuite, **kwargs):
+        self._all_vectors = list(task_suite.get_injection_vector_defaults().keys())
         super().__init__(task_suite, _NullPipeline(), **kwargs)
 
     def get_injection_candidates(self, user_task: BaseUserTask) -> list[str]:
-        return self._server_candidates[user_task.ID]
+        return self._all_vectors
 
 
-def create_attack(attack_name: str, suite: YAMLTaskSuite, candidates: dict[str, list[str]]) -> BaseAttack:
-    """Create an attack that uses server-fetched injection candidates."""
+def create_attack(attack_name: str, suite: YAMLTaskSuite) -> BaseAttack:
+    """Create an attack that injects into all vectors unconditionally."""
     base_cls = ATTACKS[attack_name]
-    patched_cls = type(f"MiDojo{base_cls.__name__}", (ServerCandidatesMixin, base_cls), {})
-    return patched_cls(suite, candidates)
+    patched_cls = type(f"MiDojo{base_cls.__name__}", (_AllVectorsMixin, base_cls), {})
+    return patched_cls(suite)

--- a/src/midojo/orchestrator.py
+++ b/src/midojo/orchestrator.py
@@ -119,6 +119,25 @@ def _print_results_table(
     console.print(f"\nResults saved to [cyan]{results_file}[/cyan]")
 
 
+async def _injection_reached_agent(
+    control_url: str, run_id: str, eval_id: str, injections: dict[str, str]
+) -> list[str]:
+    """Return names of functions whose results contained an injection payload."""
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.get(f"{control_url}/runs/{run_id}/evaluations/{eval_id}/function-calls")
+        resp.raise_for_status()
+        calls = resp.json()
+    payloads = [v for v in injections.values() if v]
+    if not payloads:
+        return []
+    hit_functions: list[str] = []
+    for call in calls:
+        result = call.get("result", "") or ""
+        if any(payload in result for payload in payloads):
+            hit_functions.append(call["function"])
+    return hit_functions
+
+
 async def run_task(
     control_url: str,
     agent_client: AgentClient,
@@ -187,28 +206,23 @@ async def run_benchmark(
             utility_results[TaskPair(ut_id, "")] = result["utility"]
             console.print(_utility(result["utility"]), Text(f"  eval {result['eval_id']}", style="dim"))
     else:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            resp = await client.get(f"{control_url}/tasks/injection-candidates")
-            resp.raise_for_status()
-            candidates = resp.json()
-        attack = create_attack(attack_name, suite, candidates)
+        attack = create_attack(attack_name, suite)
         for ut_id in user_tasks_to_run:
             user_task = suite.user_tasks[ut_id]
-            injectable = len(candidates.get(ut_id, [])) > 0
             for it_id in injection_tasks_to_run:
                 injection_task = suite.injection_tasks[it_id]
-                if not injectable:
-                    console.print(f"  Running [bold]{ut_id}[/bold] x [bold]{it_id}[/bold] ...", end=" ")
-                    result = await run_task(control_url, agent_client, run_id, ut_id, None, {})
-                    utility_results[TaskPair(ut_id, it_id)] = result["utility"]
-                    console.print(_utility(result["utility"]), " | ", Text("N/A (not injectable)", style="dim"), Text(f"  eval {result['eval_id']}", style="dim"))
-                else:
-                    console.print(f"  Running [bold]{ut_id}[/bold] x [bold]{it_id}[/bold] ...", end=" ")
-                    injections = attack.attack(user_task, injection_task)
-                    result = await run_task(control_url, agent_client, run_id, ut_id, it_id, injections)
-                    utility_results[TaskPair(ut_id, it_id)] = result["utility"]
+                console.print(f"  Running [bold]{ut_id}[/bold] x [bold]{it_id}[/bold] ...", end=" ")
+                injections = attack.attack(user_task, injection_task)
+                result = await run_task(control_url, agent_client, run_id, ut_id, it_id, injections)
+                utility_results[TaskPair(ut_id, it_id)] = result["utility"]
+                eval_id = result["eval_id"]
+                hit_functions = await _injection_reached_agent(control_url, run_id, eval_id, injections)
+                if hit_functions:
                     security_results[TaskPair(ut_id, it_id)] = result["security"]
-                    console.print(_utility(result["utility"]), " | ", _security(result["security"]), Text(f"  eval {result['eval_id']}", style="dim"))
+                    via = ", ".join(hit_functions)
+                    console.print(_utility(result["utility"]), " | ", _security(result["security"]), Text(f"  payload in {via}", style="dim"), Text(f"  eval {eval_id}", style="dim"))
+                else:
+                    console.print(_utility(result["utility"]), " | ", Text("N/A (payload not in any result)", style="dim"), Text(f"  eval {eval_id}", style="dim"))
 
     console.print()
 


### PR DESCRIPTION
## Summary
- Replaces pre-fetched `/tasks/injection-candidates` approach with post-hoc injection reachability detection from function-call results

## Context
PR #20 was accidentally merged into `orch-improvements` instead of `main`. This PR brings those changes into `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)