### PR TITLE
Improve injection reachability label in orchestrator output

### DIFF
--- a/src/midojo/orchestrator.py
+++ b/src/midojo/orchestrator.py
@@ -4,6 +4,7 @@ import asyncio
 import importlib
 import json
 import os
+from collections import Counter
 from pathlib import Path
 from typing import NamedTuple
 
@@ -239,8 +240,10 @@ async def run_benchmark(
                 console.print("    ", _utility(result["utility"]))
                 if hit_functions:
                     security_results[TaskPair(ut_id, it_id)] = result["security"]
-                    via = ", ".join(hit_functions)
-                    console.print("    ", _security(result["security"]), Text(f"  ({via})", style="dim"))
+                    counts = Counter(hit_functions)
+                    parts = [f"{fn} x{n}" if n > 1 else fn for fn, n in counts.items()]
+                    via = ", ".join(parts)
+                    console.print("    ", _security(result["security"]), Text(f"  (injection in {via})", style="dim"))
                 else:
                     console.print("    ", Text("N/A (payload not in any result)", style="dim"))
 


### PR DESCRIPTION
## Summary
- Deduplicate repeated function names using counts: `get_weather x3` instead of `get_weather, get_weather, get_weather`
- Restore descriptive prefix: `(injection in get_weather x3)` instead of `(get_weather, get_weather, get_weather)`

## Test plan
- [x] Ran full weather suite with PI agent and `--attack important_instructions`
- [x] Verified output shows `(injection in get_weather x3)` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)