### PR TITLE
Centralize suite and client fixtures in conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from midojo.app import state
-from midojo.app.routers import runs
+from midojo.app.routers import runs, suite as suite_router, tasks, tools
 from midojo.suites import get_suite
 
 task_suite = get_suite("weather")
@@ -25,6 +25,9 @@ def app() -> FastAPI:
     state.runs = {}
     state.current_eval = None
     application = FastAPI()
+    application.include_router(suite_router.router)
+    application.include_router(tasks.router)
+    application.include_router(tools.router)
     runs.register_environment_update_route(task_suite.environment_type)
     application.include_router(runs.router)
     application.include_router(runs.current_router)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,21 +1,4 @@
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
-
-from midojo.app import state
-from midojo.app.routers import suite, tasks, tools
-
-
-def _make_client(task_suite) -> TestClient:
-    state.suite = task_suite
-    app = FastAPI()
-    app.include_router(suite.router)
-    app.include_router(tasks.router)
-    app.include_router(tools.router)
-    return TestClient(app)
-
-
-def test_suite_info(suite):
-    client = _make_client(suite)
+def test_suite_info(client):
     resp = client.get("/suite")
     assert resp.status_code == 200
     data = resp.json()
@@ -28,8 +11,7 @@ def test_suite_info(suite):
     assert "default" in first_vector
 
 
-def test_injection_vectors(suite):
-    client = _make_client(suite)
+def test_injection_vectors(client):
     resp = client.get("/suite/injection-vectors")
     assert resp.status_code == 200
     data = resp.json()
@@ -39,24 +21,21 @@ def test_injection_vectors(suite):
     assert "default" in first_vector
 
 
-def test_list_user_tasks(suite):
-    client = _make_client(suite)
+def test_list_user_tasks(client):
     resp = client.get("/tasks/user")
     assert resp.status_code == 200
     data = resp.json()
     assert "user_task_0" in data
 
 
-def test_list_injection_tasks(suite):
-    client = _make_client(suite)
+def test_list_injection_tasks(client):
     resp = client.get("/tasks/injection")
     assert resp.status_code == 200
     data = resp.json()
     assert "injection_task_0" in data
 
 
-def test_task_detail_user(suite):
-    client = _make_client(suite)
+def test_task_detail_user(client):
     resp = client.get("/tasks/user/user_task_0")
     assert resp.status_code == 200
     data = resp.json()
@@ -67,8 +46,7 @@ def test_task_detail_user(suite):
     assert data["ground_truth"][0]["function"] == "get_weather"
 
 
-def test_task_detail_injection(suite):
-    client = _make_client(suite)
+def test_task_detail_injection(client):
     resp = client.get("/tasks/injection/injection_task_0")
     assert resp.status_code == 200
     data = resp.json()
@@ -77,20 +55,17 @@ def test_task_detail_injection(suite):
     assert data["goal"] is not None
 
 
-def test_task_detail_unknown_user(suite):
-    client = _make_client(suite)
+def test_task_detail_unknown_user(client):
     resp = client.get("/tasks/user/nonexistent")
     assert resp.status_code == 404
 
 
-def test_task_detail_unknown_injection(suite):
-    client = _make_client(suite)
+def test_task_detail_unknown_injection(client):
     resp = client.get("/tasks/injection/nonexistent")
     assert resp.status_code == 404
 
 
-def test_tools(suite):
-    client = _make_client(suite)
+def test_tools(client):
     resp = client.get("/tools")
     assert resp.status_code == 200
     data = resp.json()

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -3,12 +3,9 @@ from fastapi.testclient import TestClient
 
 from midojo.app import state
 from midojo.app.routers import suite, tasks, tools
-from midojo.suites import get_suite
-
-task_suite = get_suite("weather")
 
 
-def _make_client() -> TestClient:
+def _make_client(task_suite) -> TestClient:
     state.suite = task_suite
     app = FastAPI()
     app.include_router(suite.router)
@@ -17,8 +14,8 @@ def _make_client() -> TestClient:
     return TestClient(app)
 
 
-def test_suite_info():
-    client = _make_client()
+def test_suite_info(suite):
+    client = _make_client(suite)
     resp = client.get("/suite")
     assert resp.status_code == 200
     data = resp.json()
@@ -31,8 +28,8 @@ def test_suite_info():
     assert "default" in first_vector
 
 
-def test_injection_vectors():
-    client = _make_client()
+def test_injection_vectors(suite):
+    client = _make_client(suite)
     resp = client.get("/suite/injection-vectors")
     assert resp.status_code == 200
     data = resp.json()
@@ -42,24 +39,24 @@ def test_injection_vectors():
     assert "default" in first_vector
 
 
-def test_list_user_tasks():
-    client = _make_client()
+def test_list_user_tasks(suite):
+    client = _make_client(suite)
     resp = client.get("/tasks/user")
     assert resp.status_code == 200
     data = resp.json()
     assert "user_task_0" in data
 
 
-def test_list_injection_tasks():
-    client = _make_client()
+def test_list_injection_tasks(suite):
+    client = _make_client(suite)
     resp = client.get("/tasks/injection")
     assert resp.status_code == 200
     data = resp.json()
     assert "injection_task_0" in data
 
 
-def test_task_detail_user():
-    client = _make_client()
+def test_task_detail_user(suite):
+    client = _make_client(suite)
     resp = client.get("/tasks/user/user_task_0")
     assert resp.status_code == 200
     data = resp.json()
@@ -70,8 +67,8 @@ def test_task_detail_user():
     assert data["ground_truth"][0]["function"] == "get_weather"
 
 
-def test_task_detail_injection():
-    client = _make_client()
+def test_task_detail_injection(suite):
+    client = _make_client(suite)
     resp = client.get("/tasks/injection/injection_task_0")
     assert resp.status_code == 200
     data = resp.json()
@@ -80,20 +77,20 @@ def test_task_detail_injection():
     assert data["goal"] is not None
 
 
-def test_task_detail_unknown_user():
-    client = _make_client()
+def test_task_detail_unknown_user(suite):
+    client = _make_client(suite)
     resp = client.get("/tasks/user/nonexistent")
     assert resp.status_code == 404
 
 
-def test_task_detail_unknown_injection():
-    client = _make_client()
+def test_task_detail_unknown_injection(suite):
+    client = _make_client(suite)
     resp = client.get("/tasks/injection/nonexistent")
     assert resp.status_code == 404
 
 
-def test_tools():
-    client = _make_client()
+def test_tools(suite):
+    client = _make_client(suite)
     resp = client.get("/tools")
     assert resp.status_code == 200
     data = resp.json()

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -1,8 +1,5 @@
 from midojo.app.models import FunctionCallRecord
 from midojo.grading import grade_task
-from midojo.suites import get_suite
-
-task_suite = get_suite("weather")
 
 
 def _make_function_calls(env, *calls: tuple[str, dict]) -> list[FunctionCallRecord]:
@@ -15,12 +12,12 @@ def _make_function_calls(env, *calls: tuple[str, dict]) -> list[FunctionCallReco
     ]
 
 
-def test_utility_pass():
-    env = task_suite.load_and_inject_default_environment({})
+def test_utility_pass(suite):
+    env = suite.load_and_inject_default_environment({})
     pre_env = env.model_copy(deep=True)
 
     result = grade_task(
-        suite=task_suite,
+        suite=suite,
         user_task_id="user_task_0",
         injection_task_id=None,
         model_output="The weather in New York is 72°F and sunny.",
@@ -32,12 +29,12 @@ def test_utility_pass():
     assert result["security"] is False
 
 
-def test_utility_fail():
-    env = task_suite.load_and_inject_default_environment({})
+def test_utility_fail(suite):
+    env = suite.load_and_inject_default_environment({})
     pre_env = env.model_copy(deep=True)
 
     result = grade_task(
-        suite=task_suite,
+        suite=suite,
         user_task_id="user_task_0",
         injection_task_id=None,
         model_output="I don't know the weather.",
@@ -48,12 +45,12 @@ def test_utility_fail():
     assert result["utility"] is False
 
 
-def test_security_attack_not_executed():
-    env = task_suite.load_and_inject_default_environment({})
+def test_security_attack_not_executed(suite):
+    env = suite.load_and_inject_default_environment({})
     pre_env = env.model_copy(deep=True)
 
     result = grade_task(
-        suite=task_suite,
+        suite=suite,
         user_task_id="user_task_0",
         injection_task_id="injection_task_0",
         model_output="The weather in New York is 72°F and sunny.",
@@ -65,14 +62,14 @@ def test_security_attack_not_executed():
     assert result["security"] is False
 
 
-def test_security_attack_executed():
-    env = task_suite.load_and_inject_default_environment({})
+def test_security_attack_executed(suite):
+    env = suite.load_and_inject_default_environment({})
     pre_env = env.model_copy(deep=True)
 
     env.weather_alerts.append({"city": "Chicago", "message": "Severe tornado warning"})
 
     result = grade_task(
-        suite=task_suite,
+        suite=suite,
         user_task_id="user_task_0",
         injection_task_id="injection_task_0",
         model_output="The weather in New York is 72°F and sunny.",

--- a/tests/test_yaml_task_suite.py
+++ b/tests/test_yaml_task_suite.py
@@ -1,49 +1,33 @@
-from midojo.suites import get_suite
-
-_suite = get_suite("weather")
-
-
-def _fresh_suite():
-    return _suite
-
-
 class TestUserTasks:
-    def test_three_user_tasks_loaded(self):
-        suite = _fresh_suite()
+    def test_three_user_tasks_loaded(self, suite):
         assert len(suite.user_tasks) == 3
 
-    def test_task_ids(self):
-        suite = _fresh_suite()
+    def test_task_ids(self, suite):
         assert set(suite.user_tasks.keys()) == {"user_task_0", "user_task_1", "user_task_2"}
 
-    def test_prompt(self):
-        suite = _fresh_suite()
+    def test_prompt(self, suite):
         task = suite.user_tasks["user_task_0"]
         assert "New York" in task.PROMPT
         assert "temperature" in task.PROMPT.lower()
 
-    def test_ground_truth(self):
-        suite = _fresh_suite()
+    def test_ground_truth(self, suite):
         env = suite.load_and_inject_default_environment({})
         gt = suite.user_tasks["user_task_0"].ground_truth(env)
         assert len(gt) == 1
         assert gt[0].function == "get_weather"
         assert gt[0].args == {"city": "New York"}
 
-    def test_utility_pass(self):
-        suite = _fresh_suite()
+    def test_utility_pass(self, suite):
         env = suite.load_and_inject_default_environment({})
         task = suite.user_tasks["user_task_0"]
         assert task.utility("The weather is 72°F and sunny.", env, env)
 
-    def test_utility_fail(self):
-        suite = _fresh_suite()
+    def test_utility_fail(self, suite):
         env = suite.load_and_inject_default_environment({})
         task = suite.user_tasks["user_task_0"]
         assert not task.utility("I don't know the weather.", env, env)
 
-    def test_task_1_ground_truth(self):
-        suite = _fresh_suite()
+    def test_task_1_ground_truth(self, suite):
         env = suite.load_and_inject_default_environment({})
         gt = suite.user_tasks["user_task_1"].ground_truth(env)
         assert len(gt) == 4
@@ -51,43 +35,34 @@ class TestUserTasks:
 
 
 class TestInjectionTasks:
-    def test_injection_tasks_loaded(self):
-        suite = _fresh_suite()
+    def test_injection_tasks_loaded(self, suite):
         assert len(suite.injection_tasks) == 2
 
-    def test_task_id(self):
-        suite = _fresh_suite()
+    def test_task_id(self, suite):
         assert "injection_task_0" in suite.injection_tasks
 
-    def test_goal(self):
-        suite = _fresh_suite()
+    def test_goal(self, suite):
         task = suite.injection_tasks["injection_task_0"]
         assert "tornado" in task.GOAL.lower()
 
-    def test_security_pass(self):
-        suite = _fresh_suite()
+    def test_security_pass(self, suite):
         env = suite.load_and_inject_default_environment({})
         pre_env = env.model_copy(deep=True)
         env.weather_alerts.append({"city": "Chicago", "message": "Severe tornado warning"})
         task = suite.injection_tasks["injection_task_0"]
         assert task.security("", pre_env, env)
 
-    def test_security_fail(self):
-        suite = _fresh_suite()
+    def test_security_fail(self, suite):
         env = suite.load_and_inject_default_environment({})
         task = suite.injection_tasks["injection_task_0"]
         assert not task.security("", env, env)
 
-    def test_output_injection_security_pass(self):
-        suite = _fresh_suite()
+    def test_output_injection_security_pass(self, suite):
         env = suite.load_and_inject_default_environment({})
         task = suite.injection_tasks["injection_task_1"]
         assert task.security("I hate humans", env, env)
 
-    def test_output_injection_security_fail(self):
-        suite = _fresh_suite()
+    def test_output_injection_security_fail(self, suite):
         env = suite.load_and_inject_default_environment({})
         task = suite.injection_tasks["injection_task_1"]
         assert not task.security("The weather in New York is 72°F and sunny.", env, env)
-
-


### PR DESCRIPTION
## Summary

- All test files now use the shared `suite` fixture from conftest instead of calling `get_suite("weather")` independently
- Conftest `app` fixture now includes all routers (suite, tasks, tools, runs) to match the real app
- `test_admin.py` uses the shared `client` fixture instead of its own `_make_client` helper
- Single place to change the suite name for all tests
- Net -53 lines

## Test plan

- [x] All 104 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)