### PR TITLE
Delete unused injection_vectors machinery

### DIFF
--- a/src/midojo/app/models.py
+++ b/src/midojo/app/models.py
@@ -78,16 +78,10 @@ class EvaluationResponse(BaseModel):
 # --- Suite / task / tool response models ---
 
 
-class InjectionVectorInfo(BaseModel):
-    description: str
-    default: str
-
-
 class SuiteInfoResponse(BaseModel):
     user_tasks: list[str]
     injection_tasks: list[str]
     tools: list[str]
-    injection_vectors: dict[str, InjectionVectorInfo]
     environment: TaskEnvironment
 
 

--- a/src/midojo/app/routers/suite.py
+++ b/src/midojo/app/routers/suite.py
@@ -7,10 +7,7 @@ from fastapi import APIRouter, Depends, status
 from midojo.yaml_task_suite import YAMLTaskSuite
 
 from ..dependencies import get_suite
-from ..models import (
-    InjectionVectorInfo,
-    SuiteInfoResponse,
-)
+from ..models import SuiteInfoResponse
 
 router = APIRouter(prefix="/suite")
 
@@ -21,13 +18,6 @@ def suite_info(suite: Annotated[YAMLTaskSuite, Depends(get_suite)]):
         user_tasks=list(suite.user_tasks.keys()),
         injection_tasks=list(suite.injection_tasks.keys()),
         tools=suite.get_tool_names(),
-        injection_vectors=suite.get_injection_vector_info(),
         environment=suite.load_and_inject_default_environment({}),
     )
-
-
-@router.get("/injection-vectors", status_code=status.HTTP_200_OK)
-def injection_vectors(suite: Annotated[YAMLTaskSuite, Depends(get_suite)]) -> dict[str, InjectionVectorInfo]:
-    return suite.get_injection_vector_info()
-
 

--- a/src/midojo/orchestrator.py
+++ b/src/midojo/orchestrator.py
@@ -80,9 +80,7 @@ def _print_banner(
     else:
         lines.append(f"{len(user_tasks_to_run)} user (no injections)\n")
     lines.append("Tools       ", style="dim")
-    lines.append(f"{', '.join(suite_info['tools'])}\n")
-    lines.append("Vectors     ", style="dim")
-    lines.append(", ".join(suite_info["injection_vectors"].keys()) or "none")
+    lines.append(", ".join(suite_info["tools"]))
 
     console.print(Panel(lines, title="midojo orchestrator", border_style="cyan", padding=(1, 2)))
     console.print()

--- a/src/midojo/yaml_task_suite.py
+++ b/src/midojo/yaml_task_suite.py
@@ -7,9 +7,9 @@ from typing import Any, cast
 import yaml
 from agentdojo.base_tasks import BaseInjectionTask, BaseUserTask, TaskDifficulty
 from agentdojo.functions_runtime import Function, FunctionCall, TaskEnvironment
-from agentdojo.task_suite.task_suite import TaskSuite, validate_injections
+from agentdojo.task_suite.task_suite import TaskSuite
 
-from midojo.app.models import InjectionVectorInfo, ToolInfoResponse
+from midojo.app.models import ToolInfoResponse
 from midojo.env_inference import infer_environment_type
 from midojo.predicates import Predicate, evaluate_predicate, parse_predicate
 
@@ -82,29 +82,20 @@ class YAMLTaskSuite(TaskSuite):
         return cast("dict[str, MiDojoInjectionTask]", super().injection_tasks)
 
     def load_and_inject_default_environment(self, injections: dict[str, str]) -> TaskEnvironment:
+        """Render the env template with probe payloads substituted in.
+
+        `injections` is a dict keyed by `"task_id:probe_id"`. Probes are
+        scoped to a single injection task — `{task_id:probe_id}` placeholders
+        for any task whose probe isn't in the dict collapse to "". (Typo
+        detection — a `{task:probe}` pointing at nothing — is deferred.)
+        """
         env_raw = self._suite_raw["environment"]
         env_text = yaml.dump(env_raw, default_flow_style=False)
-
-        # Split into vector-style ({vector}) and probe-style ({task:probe}) keys.
-        probe_injections = {k: v for k, v in injections.items() if ":" in k}
-        vector_injections = {k: v for k, v in injections.items() if ":" not in k}
-
-        # Probe placeholders use `:` which collides with str.format's format-spec
-        # separator, so resolve them by regex first. Probes are scoped to a
-        # single injection task — placeholders for any other task collapse to ""
-        # so e.g. injection_task_2's primer doesn't leak into a run of
-        # injection_task_0. (Typo detection — a `{task:probe}` pointing at
-        # nothing — is deferred.)
         env_text = _PROBE_PLACEHOLDER_RE.sub(
-            lambda m: probe_injections.get(f"{m.group(1)}:{m.group(2)}", ""),
+            lambda m: injections.get(f"{m.group(1)}:{m.group(2)}", ""),
             env_text,
         )
-
-        injection_vector_defaults = self.get_injection_vector_defaults()
-        injections_with_defaults = dict(injection_vector_defaults, **vector_injections)
-        validate_injections(vector_injections, injection_vector_defaults)
-        injected_text = env_text.format(**injections_with_defaults)
-        return self.environment_type.model_validate(yaml.safe_load(injected_text))
+        return self.environment_type.model_validate(yaml.safe_load(env_text))
 
     def get_probes_for_task(self, task_id: str) -> dict[str, str]:
         """Return probe payloads for an injection task, keyed as `task_id:probe_id`.
@@ -127,17 +118,6 @@ class YAMLTaskSuite(TaskSuite):
 
     def get_tool_names(self) -> list[str]:
         return [t["name"] for t in self._suite_raw.get("tools", [])]
-
-    def get_injection_vector_defaults(self) -> dict[str, str]:
-        vectors_raw = self._suite_raw.get("injection_vectors", {})
-        return {vid: vinfo["default"] for vid, vinfo in vectors_raw.items()}
-
-    def get_injection_vectors_raw(self) -> dict[str, dict[str, str]]:
-        return self._suite_raw.get("injection_vectors", {})
-
-    def get_injection_vector_info(self) -> dict[str, InjectionVectorInfo]:
-        raw = self.get_injection_vectors_raw()
-        return {vid: InjectionVectorInfo(description=v["description"], default=v["default"]) for vid, v in raw.items()}
 
     def _register_tasks(self) -> None:
         for task_raw in self._suite_raw.get("user_tasks", []):

--- a/suites/weather/a2a_agent/fake_mcp.py
+++ b/suites/weather/a2a_agent/fake_mcp.py
@@ -13,8 +13,8 @@ Data flow for a read tool like get_weather:
                       |  <-- real weather data --- |
                       |
                       |  2. read injection from control plane env
-                      |     (suite.yaml defines a "notes" field
-                      |      with an {injection_weather_notes} vector)
+                      |     (suite.yaml defines a "notes" field with
+                      |      `{task_id:probe_id}` probe placeholders)
                       |
                       |  3. combine real data + injected payload
                       |  --- return to agent -->
@@ -38,7 +38,7 @@ async def get_weather(ctx: ToolContext, city: str) -> str:
     result = await ctx.forward("get_weather", {"city": city})
 
     # Injected payload from the suite environment — the "notes" field in
-    # suite.yaml can contain an injection vector like {injection_weather_notes}
+    # suite.yaml can contain probe placeholders like {injection_task_2:primer}
     # that the control plane resolves to attacker-controlled text.
     cities = await ctx.env("cities")
     data = cities.get(city)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -5,13 +5,6 @@ def test_suite_info(client):
     assert "user_task_0" in data["user_tasks"]
     assert "injection_task_0" in data["injection_tasks"]
     assert "get_weather" in data["tools"]
-    assert "injection_vectors" in data
-
-
-def test_injection_vectors(client):
-    resp = client.get("/suite/injection-vectors")
-    assert resp.status_code == 200
-    assert isinstance(resp.json(), dict)
 
 
 def test_list_user_tasks(client):


### PR DESCRIPTION
## Summary

Part of https://github.com/dmaniloff/midojo/issues/36.

After #41 every payload flows through probes and `{task_id:probe_id}` placeholders. The old `injection_vectors:` concept — named runtime-injectable slots in the env — has been dead surface area: nothing in midojo's own code constructs vector-style keys anymore, no external caller uses the endpoint or the response field, and both have been returning \`{}\` for every suite since the weather YAML lost its vectors section.

Per [this PR conversation](https://github.com/dmaniloff/midojo/pull/41), wildcard placeholders (\`{task:*}\`, \`{*}\`) will extend the **probe** namespace, not resurrect the vector registry — slot identity comes from the placeholder syntax itself, not from a separate declaration. So this cleanup doesn't preempt that work.

## What's deleted

- \`YAMLTaskSuite.get_injection_vector_defaults\` / \`_raw\` / \`_info\`
- The vector-style key split + \`str.format()\` + \`validate_injections\` pass in \`load_and_inject_default_environment\` (now just a single \`re.sub\` for probes)
- \`InjectionVectorInfo\` Pydantic model
- \`injection_vectors\` field on \`SuiteInfoResponse\`
- \`/suite/injection-vectors\` HTTP route
- Vectors line in the orchestrator banner
- \`test_injection_vectors\` and the corresponding assertion in \`test_suite_info\`
- The \`validate_injections\` import from agentdojo (no longer needed)

## What stays (intentionally)

- The probe machinery — unchanged.
- The \`re.sub\` pass that resolves \`{task_id:probe_id}\` — still there, now the only resolution step.
- Comment in \`a2a_agent/fake_mcp.py\` updated from referencing \`{injection_weather_notes}\` to \`{task_id:probe_id}\`.

## Test plan

- [x] 107 tests pass; 6 pre-existing \`test_mcp_sdk\` async failures unchanged from main.
- [x] Pyright: 17 errors (same as main baseline; no regression).
- [x] The orchestrator banner still renders (just without the now-meaningless Vectors line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)