### PR TITLE
Document PI agent model-provider setup, drop stale --attack examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,33 @@ Run the benchmark against your A2A agent:
 midojo-run \
     --agent-url http://my-agent:8000 \
     --protocol a2a \
-    --suite weather \
-    --attack direct
+    --suite weather
 ```
 
 ### With a PI agent
+
+PI agents run as local subprocesses (the orchestrator spawns `pi` per task), so a few things have to be in place before the benchmark can talk to a model:
+
+1. **Install the `pi` CLI** — see [pi.dev](https://pi.dev) for install options (npm, pnpm, bun, or the curl install script).
+2. **Per-agent config** — each PI agent in a suite ships a `.pi/settings.json` declaring its `defaultProvider` and `defaultModel`. The weather suite's agent at `suites/weather/pi_agent/.pi/settings.json` already does this:
+    ```json
+    { "defaultProvider": "litellm", "defaultModel": "llama-scout-17b" }
+    ```
+3. **Global model registry** — `pi` resolves providers from `~/.pi/agent/models.json`. The provider name there must match what the agent's `settings.json` references. For a LiteLLM proxy:
+    ```json
+    {
+      "providers": {
+        "litellm": {
+          "baseUrl": "https://your-litellm-proxy.example.com/v1",
+          "api": "openai-completions",
+          "apiKey": "LITELLM_API_KEY",
+          "models": [{ "id": "llama-scout-17b" }]
+        }
+      }
+    }
+    ```
+    The `apiKey` value is the **name** of an environment variable, not the key itself. For built-in providers (Anthropic, OpenAI, Gemini, etc.) you can skip `models.json` and just set the corresponding env var (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, ...) — see [the pi providers docs](https://pi.dev) for the full list.
+4. **Credentials in `.env`** — `uv run --env-file .env` loads them into the orchestrator's process, which forwards them to the spawned `pi` subprocess.
 
 Start the control plane:
 
@@ -107,8 +129,7 @@ Run the benchmark (PI agents use a directory path, not a URL):
 uv run --env-file .env midojo-run \
     --agent-url suites/weather/pi_agent \
     --protocol pi \
-    --suite weather \
-    --attack direct
+    --suite weather
 ```
 
 ### With an OGX agent
@@ -133,8 +154,7 @@ Run the benchmark:
 midojo-run \
     --agent-url http://localhost:8321 \
     --protocol ogx \
-    --suite weather \
-    --attack direct
+    --suite weather
 ```
 
 ### Results


### PR DESCRIPTION
## Summary

Two doc fixes, both surfaced while running the weather suite end-to-end with the PI agent.

### 1. PI agent setup is under-documented

PI agents launch as local subprocesses (the orchestrator spawns `pi` per task), so getting them to talk to a model requires three pieces that the README didn't cover:

- The `pi` CLI itself (not a Python dep — separate install via npm/pnpm/bun/curl).
- Each PI agent ships its own `.pi/settings.json` declaring a `defaultProvider` and `defaultModel`.
- `pi` looks up providers from a global `~/.pi/agent/models.json` — the provider name there must match what the agent's `settings.json` references.

The new numbered preamble in "With a PI agent" walks through all three, with a complete LiteLLM `models.json` example (the weather suite's pi_agent is already configured for `provider: litellm, model: llama-scout-17b`).

### 2. Stale `--attack` flag in three example commands

`--attack direct` appears in the A2A, PI, and OGX run examples. That flag was removed in #41 when the agentdojo attack layer was replaced by per-probe `attack_type` wrapping. Dropping all three so people who copy-paste don't hit a click error.

## Test plan

- [x] Manual: followed the new instructions to set up `~/.pi/agent/models.json` and ran the weather suite locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)