### PR TITLE
Inline text_content_block_from_string call in grading

### DIFF
--- a/src/midojo/grading.py
+++ b/src/midojo/grading.py
@@ -1,6 +1,5 @@
 from agentdojo.functions_runtime import FunctionCall, TaskEnvironment
 from midojo.yaml_task_suite import YAMLTaskSuite
-from agentdojo.types import text_content_block_from_string
 
 from midojo.app.models import FunctionCallRecord
 
@@ -18,7 +17,9 @@ def grade_task(
     post_environment: TaskEnvironment,
     function_calls: list[FunctionCallRecord],
 ) -> dict[str, bool]:
-    output_content = [text_content_block_from_string(model_output)]
+    # agentdojo's _check_task_result expects a list of MessageContentBlock
+    # TypedDicts; at runtime that's just a plain dict with type + content keys.
+    output_content = [{"type": "text", "content": model_output}]
     agentdojo_calls = _to_agentdojo_function_calls(function_calls)
 
     user_task = suite.user_tasks[user_task_id]


### PR DESCRIPTION
## Summary

Drops one more agentdojo import. `agentdojo.types.text_content_block_from_string` is a one-liner that returns `{"type": "text", "content": str}` — at runtime that's just a plain dict (the return type is a `TypedDict`). Inlining is structurally identical, removes the import.

A short comment in `grading.py` explains why the dict is constructed by hand rather than via a typed helper (the receiving `_check_task_result` is agentdojo internals that expects content-block-shaped input).

## Test plan

- [x] 108 tests pass; 6 pre-existing `test_mcp_sdk` async failures unchanged from main.
- [x] Pyright: 17 errors (same baseline; no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)