### PR TITLE
Drop SuiteResults return type from run_benchmark

### DIFF
--- a/src/midojo/orchestrator.py
+++ b/src/midojo/orchestrator.py
@@ -10,7 +10,6 @@ from typing import NamedTuple
 
 import click
 import httpx
-from agentdojo.benchmark import SuiteResults
 from midojo.yaml_task_suite import YAMLTaskSuite
 from rich.console import Console
 from rich.panel import Panel
@@ -200,7 +199,7 @@ async def run_benchmark(
     user_task_ids: list[str] | None,
     injection_task_ids: list[str] | None,
     logdir: Path,
-) -> SuiteResults:
+) -> None:
     user_tasks_to_run = user_task_ids or list(suite.user_tasks.keys())
     injection_tasks_to_run: list[str]
     if injection_task_ids is not None:
@@ -260,12 +259,6 @@ async def run_benchmark(
         )
 
     _print_results_table(utility_results, security_results, bool(injection_tasks_to_run), results_file)
-
-    return SuiteResults(
-        utility_results=utility_results,
-        security_results=security_results,
-        injection_tasks_utility_results={},
-    )
 
 
 @click.command()


### PR DESCRIPTION
## Summary

`run_benchmark` is only called from the CLI entrypoint in the same file, which wraps it in `asyncio.run()` and discards the return value. The `SuiteResults` TypedDict from `agentdojo.benchmark` was being constructed only to be thrown away. Changing the return type to `None` drops the agentdojo import and the no-op return statement.

## Bonus pyright cleanup

This clears two pre-existing pyright errors that were complaining about the orchestrator passing `dict[TaskPair, bool]` (a `NamedTuple`-keyed dict) into `SuiteResults`'s declared `dict[tuple[str, str], bool]` field. `dict` is invariant in key type, so `TaskPair` (a `NamedTuple` subclass of `tuple`) didn't satisfy `tuple[str, str]`. Pyright drops from 17 errors to 15.

## Test plan

- [x] 108 tests pass; 6 pre-existing `test_mcp_sdk` async failures unchanged.
- [x] Pyright: 15 errors (down from 17 — two SuiteResults-related errors gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)