### PR TITLE
Define local Environment base class, drop agentdojo TaskEnvironment

### DIFF
--- a/src/midojo/app/models.py
+++ b/src/midojo/app/models.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from agentdojo.functions_runtime import TaskEnvironment
 from pydantic import BaseModel, ConfigDict, SerializeAsAny
 
+from midojo.types import Environment
 
 # --- Run / Evaluation request/response models ---
 
@@ -60,8 +60,8 @@ class FunctionCallRecord(CreateFunctionCallRecord):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     timestamp: str
-    pre_environment: SerializeAsAny[TaskEnvironment]
-    post_environment: SerializeAsAny[TaskEnvironment]
+    pre_environment: SerializeAsAny[Environment]
+    post_environment: SerializeAsAny[Environment]
 
 
 class EvaluationResponse(BaseModel):
@@ -83,7 +83,7 @@ class SuiteInfoResponse(BaseModel):
     user_tasks: list[str]
     injection_tasks: list[str]
     tools: list[str]
-    environment: TaskEnvironment
+    environment: Environment
 
 
 class TaskDetailResponse(BaseModel):

--- a/src/midojo/app/state.py
+++ b/src/midojo/app/state.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from agentdojo.functions_runtime import TaskEnvironment
+
 from pydantic import BaseModel, ConfigDict, Field
 
+from midojo.types import Environment
 from midojo.yaml_task_suite import YAMLTaskSuite
 
 from .models import FunctionCallRecord
@@ -31,8 +32,8 @@ class Evaluation:
     id: str
     user_task_id: str
     injection_task_id: str | None
-    pre_environment: TaskEnvironment
-    environment: TaskEnvironment
+    pre_environment: Environment
+    environment: Environment
     function_calls: list[FunctionCallRecord] = field(default_factory=list)
     agent_input: str | None = None
     agent_output: str | None = None

--- a/src/midojo/env_inference.py
+++ b/src/midojo/env_inference.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from agentdojo.functions_runtime import TaskEnvironment
 from pydantic import create_model
+
+from midojo.types import Environment
 
 
 def _infer_type(value: Any, model_name: str) -> type:
@@ -55,9 +56,9 @@ def _infer_field(key: str, value: Any, suite_name: str) -> tuple[type, Any]:
     return (_infer_type(value, f"{suite_name}_{key}"), ...)
 
 
-def infer_environment_type(suite_name: str, env_data: dict) -> type[TaskEnvironment]:
+def infer_environment_type(suite_name: str, env_data: dict) -> type[Environment]:
     label = suite_name.title().replace(" ", "")
     fields: dict[str, Any] = {}
     for key, value in env_data.items():
         fields[key] = _infer_field(key, value, label)
-    return create_model(f"{label}Environment", __base__=TaskEnvironment, **fields)
+    return create_model(f"{label}Environment", __base__=Environment, **fields)

--- a/src/midojo/grading.py
+++ b/src/midojo/grading.py
@@ -1,7 +1,8 @@
-from agentdojo.functions_runtime import FunctionCall, TaskEnvironment
-from midojo.yaml_task_suite import YAMLTaskSuite
+from agentdojo.functions_runtime import FunctionCall
 
 from midojo.app.models import FunctionCallRecord
+from midojo.types import Environment
+from midojo.yaml_task_suite import YAMLTaskSuite
 
 
 def _to_agentdojo_function_calls(records: list[FunctionCallRecord]) -> list[FunctionCall]:
@@ -13,8 +14,8 @@ def grade_task(
     user_task_id: str,
     injection_task_id: str | None,
     agent_output: str,
-    pre_environment: TaskEnvironment,
-    post_environment: TaskEnvironment,
+    pre_environment: Environment,
+    post_environment: Environment,
     function_calls: list[FunctionCallRecord],
 ) -> dict[str, bool]:
     # agentdojo's _check_task_result expects a list of MessageContentBlock

--- a/src/midojo/predicates.py
+++ b/src/midojo/predicates.py
@@ -16,10 +16,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from agentdojo.functions_runtime import TaskEnvironment
+from midojo.types import Environment
 
 
-def resolve_field(env: TaskEnvironment, path: str) -> Any:
+def resolve_field(env: Environment, path: str) -> Any:
     """Walk a dotted path into a Pydantic model."""
     current: Any = env
     for key in path.split("."):
@@ -39,7 +39,7 @@ def resolve_field(env: TaskEnvironment, path: str) -> Any:
 class OutputContains:
     value: str
 
-    def evaluate(self, agent_output: str, pre_env: TaskEnvironment, post_env: TaskEnvironment) -> bool:
+    def evaluate(self, agent_output: str, pre_env: Environment, post_env: Environment) -> bool:
         return self.value.lower() in agent_output.lower()
 
 
@@ -47,7 +47,7 @@ class OutputContains:
 class OutputContainsAll:
     values: list[str]
 
-    def evaluate(self, agent_output: str, pre_env: TaskEnvironment, post_env: TaskEnvironment) -> bool:
+    def evaluate(self, agent_output: str, pre_env: Environment, post_env: Environment) -> bool:
         lower = agent_output.lower()
         return all(v.lower() in lower for v in self.values)
 
@@ -56,7 +56,7 @@ class OutputContainsAll:
 class OutputContainsAny:
     values: list[str]
 
-    def evaluate(self, agent_output: str, pre_env: TaskEnvironment, post_env: TaskEnvironment) -> bool:
+    def evaluate(self, agent_output: str, pre_env: Environment, post_env: Environment) -> bool:
         lower = agent_output.lower()
         return any(v.lower() in lower for v in self.values)
 
@@ -66,7 +66,7 @@ class EnvFieldEquals:
     field: str
     value: Any
 
-    def evaluate(self, agent_output: str, pre_env: TaskEnvironment, post_env: TaskEnvironment) -> bool:
+    def evaluate(self, agent_output: str, pre_env: Environment, post_env: Environment) -> bool:
         return resolve_field(post_env, self.field) == self.value
 
 
@@ -75,7 +75,7 @@ class EnvFieldContains:
     field: str
     value: str
 
-    def evaluate(self, agent_output: str, pre_env: TaskEnvironment, post_env: TaskEnvironment) -> bool:
+    def evaluate(self, agent_output: str, pre_env: Environment, post_env: Environment) -> bool:
         field_val = resolve_field(post_env, self.field)
         return self.value.lower() in str(field_val).lower()
 
@@ -85,7 +85,7 @@ class EnvListAnyMatch:
     field: str
     match: dict[str, str]
 
-    def evaluate(self, agent_output: str, pre_env: TaskEnvironment, post_env: TaskEnvironment) -> bool:
+    def evaluate(self, agent_output: str, pre_env: Environment, post_env: Environment) -> bool:
         items = resolve_field(post_env, self.field)
         if not isinstance(items, list):
             return False
@@ -106,7 +106,7 @@ class EnvListCount:
     field: str
     count: int
 
-    def evaluate(self, agent_output: str, pre_env: TaskEnvironment, post_env: TaskEnvironment) -> bool:
+    def evaluate(self, agent_output: str, pre_env: Environment, post_env: Environment) -> bool:
         items = resolve_field(post_env, self.field)
         return isinstance(items, list) and len(items) == self.count
 
@@ -115,7 +115,7 @@ class EnvListCount:
 class EnvFieldUnchanged:
     field: str
 
-    def evaluate(self, agent_output: str, pre_env: TaskEnvironment, post_env: TaskEnvironment) -> bool:
+    def evaluate(self, agent_output: str, pre_env: Environment, post_env: Environment) -> bool:
         return resolve_field(pre_env, self.field) == resolve_field(post_env, self.field)
 
 
@@ -123,7 +123,7 @@ class EnvFieldUnchanged:
 class AllOf:
     predicates: list[Predicate]
 
-    def evaluate(self, agent_output: str, pre_env: TaskEnvironment, post_env: TaskEnvironment) -> bool:
+    def evaluate(self, agent_output: str, pre_env: Environment, post_env: Environment) -> bool:
         return all(p.evaluate(agent_output, pre_env, post_env) for p in self.predicates)
 
 
@@ -131,7 +131,7 @@ class AllOf:
 class AnyOf:
     predicates: list[Predicate]
 
-    def evaluate(self, agent_output: str, pre_env: TaskEnvironment, post_env: TaskEnvironment) -> bool:
+    def evaluate(self, agent_output: str, pre_env: Environment, post_env: Environment) -> bool:
         return any(p.evaluate(agent_output, pre_env, post_env) for p in self.predicates)
 
 
@@ -139,7 +139,7 @@ class AnyOf:
 class Not:
     predicate: Predicate
 
-    def evaluate(self, agent_output: str, pre_env: TaskEnvironment, post_env: TaskEnvironment) -> bool:
+    def evaluate(self, agent_output: str, pre_env: Environment, post_env: Environment) -> bool:
         return not self.predicate.evaluate(agent_output, pre_env, post_env)
 
 
@@ -213,6 +213,6 @@ def parse_predicate(raw: dict) -> Predicate:
 
 
 def evaluate_predicate(
-    predicate: Predicate, agent_output: str, pre_env: TaskEnvironment, post_env: TaskEnvironment
+    predicate: Predicate, agent_output: str, pre_env: Environment, post_env: Environment
 ) -> bool:
     return predicate.evaluate(agent_output, pre_env, post_env)

--- a/src/midojo/types.py
+++ b/src/midojo/types.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+class Environment(BaseModel):
+    """Base class for suite environments."""
+
+    ...

--- a/src/midojo/yaml_task_suite.py
+++ b/src/midojo/yaml_task_suite.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 import yaml
 from agentdojo.base_tasks import BaseInjectionTask, BaseUserTask
-from agentdojo.functions_runtime import TaskEnvironment
+from midojo.types import Environment
 from agentdojo.task_suite.task_suite import TaskSuite
 
 from midojo.app.models import ToolInfoResponse
@@ -66,7 +66,7 @@ class YAMLTaskSuite(TaskSuite):
         self,
         name: str,
         suite_yaml_path: Path,
-        environment_type: type[TaskEnvironment] | None = None,
+        environment_type: type[Environment] | None = None,
     ) -> None:
         self._suite_yaml_path = suite_yaml_path
         self._suite_raw: dict = yaml.safe_load(suite_yaml_path.read_text())
@@ -87,7 +87,7 @@ class YAMLTaskSuite(TaskSuite):
         # instances, so the cast is sound in practice.
         return cast("dict[str, MiDojoInjectionTask]", super().injection_tasks)
 
-    def load_and_inject_default_environment(self, injections: dict[str, str]) -> TaskEnvironment:
+    def load_and_inject_default_environment(self, injections: dict[str, str]) -> Environment:
         """Render the env template with probe payloads substituted in.
 
         Tool-output delivery path: probes land in env fields that fake tools
@@ -183,14 +183,14 @@ class YAMLTaskSuite(TaskSuite):
         prompt: str,
         predicate: Predicate,
     ) -> type[BaseUserTask]:
-        def ground_truth(self: Any, pre_environment: TaskEnvironment) -> list:
+        def ground_truth(self: Any, pre_environment: Environment) -> list:
             return []
 
         def utility(
             self: Any,
             agent_output: str,
-            pre_environment: TaskEnvironment,
-            post_environment: TaskEnvironment,
+            pre_environment: Environment,
+            post_environment: Environment,
             strict: bool = True,
         ) -> bool:
             return evaluate_predicate(predicate, agent_output, pre_environment, post_environment)
@@ -212,14 +212,14 @@ class YAMLTaskSuite(TaskSuite):
         predicate: Predicate,
         probes: dict[str, str],
     ) -> type[MiDojoInjectionTask]:
-        def ground_truth(self: Any, pre_environment: TaskEnvironment) -> list:
+        def ground_truth(self: Any, pre_environment: Environment) -> list:
             return []
 
         def security(
             self: Any,
             agent_output: str,
-            pre_environment: TaskEnvironment,
-            post_environment: TaskEnvironment,
+            pre_environment: Environment,
+            post_environment: Environment,
         ) -> bool:
             return evaluate_predicate(predicate, agent_output, pre_environment, post_environment)
 

--- a/tests/test_env_inference.py
+++ b/tests/test_env_inference.py
@@ -1,12 +1,11 @@
-from agentdojo.functions_runtime import TaskEnvironment
-
 from midojo.env_inference import infer_environment_type
+from midojo.types import Environment
 
 
 def test_scalar_fields():
     env_data = {"name": "test", "count": 5, "ratio": 3.14, "active": True}
     EnvType = infer_environment_type("demo", env_data)
-    assert issubclass(EnvType, TaskEnvironment)
+    assert issubclass(EnvType, Environment)
 
     instance = EnvType.model_validate(env_data)
     assert instance.name == "test"

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -1,5 +1,4 @@
 import pytest
-from agentdojo.functions_runtime import TaskEnvironment
 from pydantic import BaseModel
 
 from midojo.predicates import (
@@ -17,17 +16,18 @@ from midojo.predicates import (
     evaluate_predicate,
     parse_predicate,
 )
+from midojo.types import Environment
 
 
-class EmptyEnv(TaskEnvironment):
+class EmptyEnv(Environment):
     pass
 
 
-class CountEnv(TaskEnvironment):
+class CountEnv(Environment):
     count: int = 0
 
 
-class MessageEnv(TaskEnvironment):
+class MessageEnv(Environment):
     message: str = ""
 
 
@@ -36,19 +36,19 @@ class Alert(BaseModel):
     message: str
 
 
-class AlertsEnv(TaskEnvironment):
+class AlertsEnv(Environment):
     weather_alerts: list[Alert] = []
 
 
-class ItemsEnv(TaskEnvironment):
+class ItemsEnv(Environment):
     items: list = []
 
 
-class BalanceEnv(TaskEnvironment):
+class BalanceEnv(Environment):
     balance: int = 0
 
 
-class StatusItemsEnv(TaskEnvironment):
+class StatusItemsEnv(Environment):
     status: str = ""
     items: list = []
 
@@ -57,7 +57,7 @@ class CityCondition(BaseModel):
     condition: str
 
 
-class CitiesEnv(TaskEnvironment):
+class CitiesEnv(Environment):
     cities: dict[str, CityCondition] = {}
 
 


### PR DESCRIPTION
## Summary
- Introduces `midojo.types.Environment`, a plain `BaseModel` subclass replacing `agentdojo.functions_runtime.TaskEnvironment`
- Updates all imports across 6 source files and 2 test files — no behavioral change
- First step toward fully removing the `agentdojo` dependency (#56)

## Test plan
- [x] All 117 tests pass
- [x] `ruff check` clean on changed files
- [x] No remaining `TaskEnvironment` references in src/ or tests/

🤖 Generated with [Claude Code](https://claude.com/claude-code)