### PR TITLE
Inline grading: drop agentdojo FunctionCall

### DIFF
--- a/src/midojo/grading.py
+++ b/src/midojo/grading.py
@@ -1,12 +1,6 @@
-from agentdojo.functions_runtime import FunctionCall
-
 from midojo.app.models import FunctionCallRecord
 from midojo.types import Environment
 from midojo.yaml_task_suite import YAMLTaskSuite
-
-
-def _to_agentdojo_function_calls(records: list[FunctionCallRecord]) -> list[FunctionCall]:
-    return [FunctionCall(function=r.function, args=r.args) for r in records]
 
 
 def grade_task(
@@ -18,20 +12,13 @@ def grade_task(
     post_environment: Environment,
     function_calls: list[FunctionCallRecord],
 ) -> dict[str, bool]:
-    # agentdojo's _check_task_result expects a list of MessageContentBlock
-    # TypedDicts; at runtime that's just a plain dict with type + content keys.
-    output_content = [{"type": "text", "content": agent_output}]
-    agentdojo_calls = _to_agentdojo_function_calls(function_calls)
-
     user_task = suite.user_tasks[user_task_id]
-    utility = suite._check_task_result(user_task, output_content, pre_environment, post_environment, agentdojo_calls)
+    utility = user_task.utility(agent_output, pre_environment, post_environment)
 
-    security = (
-        suite._check_task_result(
-            suite.injection_tasks[injection_task_id], output_content, pre_environment, post_environment, agentdojo_calls
-        )
-        if injection_task_id is not None
-        else False
-    )
+    if injection_task_id is not None:
+        injection_task = suite.injection_tasks[injection_task_id]
+        security = injection_task.security(agent_output, pre_environment, post_environment)
+    else:
+        security = False
 
     return {"utility": utility, "security": security}


### PR DESCRIPTION
Part of https://github.com/dmaniloff/midojo/issues/56

## Summary
- Calls `task.utility()` / `task.security()` directly instead of routing through agentdojo's `_check_task_result` dispatch
- Removes `FunctionCall` import, `_to_agentdojo_function_calls()` helper, and content-block wrapping
- `grading.py` now has zero agentdojo imports

The `_check_task_result` → `_check_user_task_utility` → `task.utility()` chain was a no-op for midojo's predicate-based tasks (`utility_from_traces` always returns `None`).

## Test plan
- [x] All 117 tests pass
- [x] Net -15 lines removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)