### PR TITLE
Make --suite required for midojo-serve and midojo-run

### DIFF
--- a/src/midojo/orchestrator.py
+++ b/src/midojo/orchestrator.py
@@ -275,7 +275,7 @@ async def run_benchmark(
 @click.command()
 @click.option("--control-url", default="http://localhost:8080", help="URL of the benchmark MCP server control plane.")
 @click.option("--agent-url", required=True, help="URL of the agent to test.")
-@click.option("--suite", "suite_name", default="weather", help="Benchmark suite name.")
+@click.option("--suite", "suite_name", required=True, help="Benchmark suite name.")
 @click.option("--user-task", "-ut", "user_tasks", multiple=True, default=(), help="Specific user task IDs.")
 @click.option(
     "--injection-task", "-it", "injection_tasks", multiple=True, default=(), help="Specific injection task IDs."

--- a/src/midojo/orchestrator.py
+++ b/src/midojo/orchestrator.py
@@ -17,7 +17,7 @@ from rich.table import Table
 from rich.text import Text
 
 from midojo.agent_client import A2AAgentClient, AgentClient, OGXResponsesClient, PIAgentClient, SimpleHTTPAgentClient
-from midojo.suites import get_suite
+from midojo.suites import get_suite, list_suites
 
 console = Console()
 
@@ -275,7 +275,7 @@ async def run_benchmark(
 @click.command()
 @click.option("--control-url", default="http://localhost:8080", help="URL of the benchmark MCP server control plane.")
 @click.option("--agent-url", required=True, help="URL of the agent to test.")
-@click.option("--suite", "suite_name", required=True, help="Benchmark suite name.")
+@click.option("--suite", "suite_name", required=True, help=f"Benchmark suite name. Built-in: {', '.join(list_suites())}.")
 @click.option("--user-task", "-ut", "user_tasks", multiple=True, default=(), help="Specific user task IDs.")
 @click.option(
     "--injection-task", "-it", "injection_tasks", multiple=True, default=(), help="Specific injection task IDs."

--- a/src/midojo/serve.py
+++ b/src/midojo/serve.py
@@ -4,13 +4,13 @@ import click
 import uvicorn
 
 from midojo.app.main import create_app
-from midojo.suites import get_suite
+from midojo.suites import get_suite, list_suites
 
 
 @click.command()
 @click.option("--host", default="0.0.0.0", help="Host to bind to.")
 @click.option("--port", default=8080, type=int, help="Port to bind to.")
-@click.option("--suite", "suite_name", required=True, help="Benchmark suite name.")
+@click.option("--suite", "suite_name", required=True, help=f"Benchmark suite name. Built-in: {', '.join(list_suites())}.")
 def main(host: str, port: int, suite_name: str) -> None:
     suite = get_suite(suite_name)
 

--- a/src/midojo/serve.py
+++ b/src/midojo/serve.py
@@ -10,7 +10,7 @@ from midojo.suites import get_suite
 @click.command()
 @click.option("--host", default="0.0.0.0", help="Host to bind to.")
 @click.option("--port", default=8080, type=int, help="Port to bind to.")
-@click.option("--suite", "suite_name", default="weather", help="Benchmark suite name.")
+@click.option("--suite", "suite_name", required=True, help="Benchmark suite name.")
 def main(host: str, port: int, suite_name: str) -> None:
     suite = get_suite(suite_name)
 

--- a/src/midojo/suites.py
+++ b/src/midojo/suites.py
@@ -6,6 +6,14 @@ from pathlib import Path
 from midojo.yaml_task_suite import YAMLTaskSuite
 
 
+def list_suites() -> list[str]:
+    """Return sorted names of built-in suites (directories under ``suites/`` with a ``suite.yaml``)."""
+    suites_dir = Path(importlib.import_module("suites").__file__).parent
+    return sorted(
+        p.parent.name for p in suites_dir.glob("*/suite.yaml")
+    )
+
+
 def get_suite(spec: str) -> YAMLTaskSuite:
     """Load a suite by name.
 


### PR DESCRIPTION
## Summary
- Remove the `default="weather"` from `--suite` in both `midojo-serve` and `midojo-run`, making it a required option
- Prevents silent suite mismatches (e.g. running a minibank agent against a server that loaded the weather suite, which produces a confusing 400 on the evaluations endpoint)

## Test plan
- [ ] Run `midojo-serve` without `--suite` and verify it errors with a clear "Missing option" message
- [ ] Run `midojo-run` without `--suite` and verify the same
- [ ] Run `midojo-serve --suite minibank` and `midojo-run --suite minibank ...` and verify they work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)