### PR TITLE
Split FunctionCallRecord into a domain type and lean API DTOs

### DIFF
--- a/src/midojo/app/models.py
+++ b/src/midojo/app/models.py
@@ -1,10 +1,32 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, SerializeAsAny
+from pydantic import BaseModel, ConfigDict
 
 from midojo.types import Environment
 
 # --- Run / Evaluation request/response models ---
+
+
+class CreateFunctionCallRecord(BaseModel):
+    """Request body for recording a function call (server fills in timestamp + env snapshots)."""
+
+    function: str
+    args: dict
+    result: str
+    error: str | None = None
+
+
+class FunctionCallResponse(CreateFunctionCallRecord):
+    """Public shape of a recorded function call.
+
+    Excludes the internal pre/post environment snapshots that the domain
+    ``FunctionCallRecord`` carries for grading — no API client consumes them.
+    ``from_attributes`` lets it be built directly from a domain record.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    timestamp: str
 
 
 class CreateEvaluationRequest(BaseModel):
@@ -46,23 +68,6 @@ class RunResponse(BaseModel):
     evaluations: list[EvaluationSummary]
 
 
-class CreateFunctionCallRecord(BaseModel):
-    function: str
-    args: dict
-    result: str
-    error: str | None = None
-
-
-class FunctionCallRecord(CreateFunctionCallRecord):
-    """A recorded function call execution (function + args + result + env snapshots)."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    timestamp: str
-    pre_environment: SerializeAsAny[Environment]
-    post_environment: SerializeAsAny[Environment]
-
-
 class EvaluationResponse(BaseModel):
     id: str
     user_task_id: str
@@ -72,7 +77,7 @@ class EvaluationResponse(BaseModel):
     security: bool | None
     agent_input: str | None
     agent_output: str | None
-    function_calls: list[FunctionCallRecord]
+    function_calls: list[FunctionCallResponse]
 
 
 # --- Suite / task / tool response models ---

--- a/src/midojo/app/routers/runs.py
+++ b/src/midojo/app/routers/runs.py
@@ -5,6 +5,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
+from midojo.types import FunctionCallRecord
 from midojo.yaml_task_suite import YAMLTaskSuite
 
 from .. import state
@@ -13,11 +14,11 @@ from ..models import (
     CompleteRequest,
     CreateEvaluationRequest,
     CreateEvaluationResponse,
+    CreateFunctionCallRecord,
     CreateRunResponse,
     EvaluationResponse,
     EvaluationSummary,
-    FunctionCallRecord,
-    CreateFunctionCallRecord,
+    FunctionCallResponse,
     GradeResponse,
     RunResponse,
 )
@@ -89,13 +90,9 @@ def create_evaluation(
     return CreateEvaluationResponse(id=evaluation.id, prompt=prompt)
 
 
-_FC_ENV_FIELDS = {"pre_environment", "post_environment"}
-
-
 @router.get(
     "/{run_id}/evaluations/{eval_id}",
     response_model=EvaluationResponse,
-    response_model_exclude={"function_calls": {"__all__": _FC_ENV_FIELDS}},
     status_code=status.HTTP_200_OK,
 )
 def retrieve_evaluation(evaluation: Annotated[Evaluation, Depends(get_evaluation_by_id)]):
@@ -108,7 +105,7 @@ def retrieve_evaluation(evaluation: Annotated[Evaluation, Depends(get_evaluation
         security=evaluation.security,
         agent_input=evaluation.agent_input,
         agent_output=evaluation.agent_output,
-        function_calls=evaluation.function_calls,
+        function_calls=[FunctionCallResponse.model_validate(fc) for fc in evaluation.function_calls],
     )
 
 
@@ -159,14 +156,13 @@ def register_environment_update_route(env_type: type) -> None:
     register these routes at startup once the suite type is known, patching __annotations__
     on the handler to give FastAPI the right body type.
     """
+
     def update_environment(body, evaluation: Annotated[Evaluation, Depends(get_evaluation_by_id)]) -> dict:
         evaluation.environment = body
         return evaluation.environment.model_dump()
 
     update_environment.__annotations__["body"] = env_type
-    router.add_api_route(
-        "/{run_id}/evaluations/{eval_id}/environment", update_environment, methods=["PUT"]
-    )
+    router.add_api_route("/{run_id}/evaluations/{eval_id}/environment", update_environment, methods=["PUT"])
 
     def update_current_environment(body, evaluation: Annotated[Evaluation, Depends(get_current_evaluation)]) -> dict:
         evaluation.environment = body
@@ -181,8 +177,7 @@ def register_environment_update_route(env_type: type) -> None:
 
 @router.get(
     "/{run_id}/evaluations/{eval_id}/function-calls",
-    response_model=list[FunctionCallRecord],
-    response_model_exclude={"__all__": _FC_ENV_FIELDS},
+    response_model=list[FunctionCallResponse],
     status_code=status.HTTP_200_OK,
 )
 def list_function_calls(evaluation: Annotated[Evaluation, Depends(get_evaluation_by_id)]) -> list[FunctionCallRecord]:
@@ -191,7 +186,7 @@ def list_function_calls(evaluation: Annotated[Evaluation, Depends(get_evaluation
 
 @router.get(
     "/{run_id}/evaluations/{eval_id}/function-calls/{idx}",
-    response_model=FunctionCallRecord,
+    response_model=FunctionCallResponse,
     status_code=status.HTTP_200_OK,
 )
 def get_function_call(idx: int, evaluation: Annotated[Evaluation, Depends(get_evaluation_by_id)]) -> FunctionCallRecord:
@@ -217,7 +212,7 @@ def _append_function_call(req: CreateFunctionCallRecord, evaluation: Evaluation)
 
 @router.post(
     "/{run_id}/evaluations/{eval_id}/function-calls",
-    response_model=FunctionCallRecord,
+    response_model=FunctionCallResponse,
     status_code=status.HTTP_201_CREATED,
 )
 def record_function_call(
@@ -237,8 +232,7 @@ def get_current_environment(evaluation: Annotated[Evaluation, Depends(get_curren
 
 @current_router.get(
     "/function-calls",
-    response_model=list[FunctionCallRecord],
-    response_model_exclude={"__all__": _FC_ENV_FIELDS},
+    response_model=list[FunctionCallResponse],
     status_code=status.HTTP_200_OK,
 )
 def list_current_function_calls(
@@ -249,7 +243,7 @@ def list_current_function_calls(
 
 @current_router.get(
     "/function-calls/{idx}",
-    response_model=FunctionCallRecord,
+    response_model=FunctionCallResponse,
     status_code=status.HTTP_200_OK,
 )
 def get_current_function_call(
@@ -262,7 +256,7 @@ def get_current_function_call(
 
 @current_router.post(
     "/function-calls",
-    response_model=FunctionCallRecord,
+    response_model=FunctionCallResponse,
     status_code=status.HTTP_201_CREATED,
 )
 def record_current_function_call(

--- a/src/midojo/app/state.py
+++ b/src/midojo/app/state.py
@@ -12,10 +12,8 @@ from datetime import datetime, timezone
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from midojo.types import Environment
+from midojo.types import Environment, FunctionCallRecord
 from midojo.yaml_task_suite import YAMLTaskSuite
-
-from .models import FunctionCallRecord
 
 
 def _new_id() -> str:

--- a/src/midojo/types.py
+++ b/src/midojo/types.py
@@ -1,7 +1,21 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, SerializeAsAny
 
 
 class Environment(BaseModel):
     """Base class for suite environments."""
 
     ...
+
+
+class FunctionCallRecord(BaseModel):
+    """A recorded function call execution (function + args + result + env snapshots)."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    function: str
+    args: dict
+    result: str
+    error: str | None = None
+    timestamp: str
+    pre_environment: SerializeAsAny[Environment]
+    post_environment: SerializeAsAny[Environment]

--- a/src/midojo/yaml_task_suite.py
+++ b/src/midojo/yaml_task_suite.py
@@ -6,11 +6,11 @@ from pathlib import Path
 
 import yaml
 
-from midojo.app.models import FunctionCallRecord, ToolInfoResponse
+from midojo.app.models import ToolInfoResponse
 from midojo.attack_types import wrap_payload
 from midojo.env_inference import infer_environment_type
 from midojo.predicates import Predicate, evaluate_predicate, parse_predicate
-from midojo.types import Environment
+from midojo.types import Environment, FunctionCallRecord
 
 
 @dataclass

--- a/tests/test_control_api.py
+++ b/tests/test_control_api.py
@@ -1,7 +1,7 @@
 from fastapi.testclient import TestClient
 
 from midojo.app import state
-from midojo.app.models import FunctionCallRecord
+from midojo.types import FunctionCallRecord
 
 
 def _create_run(client: TestClient) -> str:
@@ -204,41 +204,51 @@ def test_record_function_call_via_post(client):
     assert record["result"] == "72°F, sunny"
     assert record["error"] is None
     assert "timestamp" in record
-    assert "pre_environment" in record
-    assert "post_environment" in record
+    # Env snapshots are internal server state, not part of the public response.
+    assert "pre_environment" not in record
+    assert "post_environment" not in record
 
     resp = client.get(f"/runs/{run_id}/evaluations/{eval_id}/function-calls")
     assert resp.status_code == 200
     assert len(resp.json()) == 1
 
+    # ...but they are still captured server-side for grading.
+    recorded = state.current_eval.function_calls[0]
+    assert recorded.pre_environment is not None
+    assert recorded.post_environment is not None
+
 
 def test_record_function_call_pre_env_chain(client):
-    """pre_environment of each call should match post_environment of the previous call."""
+    """pre_environment of each call should match post_environment of the previous call.
+
+    The chaining is an internal invariant (env snapshots aren't exposed over the
+    API), so it's asserted against the recorded server-side state.
+    """
     run_id = _create_run(client)
     eval_data = _create_evaluation(client, run_id)
     eval_id = eval_data["id"]
 
     initial_env = client.get(f"/runs/{run_id}/evaluations/{eval_id}/environment").json()
 
-    resp1 = client.post(
+    client.post(
         f"/runs/{run_id}/evaluations/{eval_id}/function-calls",
         json={"function": "get_weather", "args": {"city": "New York"}, "result": "72°F, sunny"},
     )
-    record1 = resp1.json()
-    assert record1["pre_environment"] == initial_env
 
     client.put(
         f"/runs/{run_id}/evaluations/{eval_id}/environment",
         json={**initial_env, "weather_alerts": [{"city": "New York", "message": "Storm warning"}]},
     )
 
-    resp2 = client.post(
+    client.post(
         f"/runs/{run_id}/evaluations/{eval_id}/function-calls",
         json={"function": "send_weather_alert", "args": {"city": "New York", "message": "Storm warning"}, "result": "ok"},
     )
-    record2 = resp2.json()
-    assert record2["pre_environment"] == record1["post_environment"]
-    assert record2["post_environment"]["weather_alerts"] == [{"city": "New York", "message": "Storm warning"}]
+
+    calls = state.current_eval.function_calls
+    assert calls[0].pre_environment.model_dump() == initial_env
+    assert calls[1].pre_environment == calls[0].post_environment
+    assert calls[1].post_environment.model_dump()["weather_alerts"] == [{"city": "New York", "message": "Storm warning"}]
 
 
 # --- /current/* endpoints ---

--- a/tests/test_grading.py
+++ b/tests/test_grading.py
@@ -1,4 +1,4 @@
-from midojo.app.models import FunctionCallRecord
+from midojo.types import FunctionCallRecord
 
 
 def _make_function_calls(env, *calls: tuple[str, dict]) -> list[FunctionCallRecord]:


### PR DESCRIPTION
## What

Separates the function-call data model along its real seams, and tightens the control-plane contract.

- **`types.py`** owns the domain `FunctionCallRecord` (standalone: call + `timestamp` + pre/post env snapshots), so core code no longer imports the web layer.
- **`app/models.py`** owns the API DTOs: `CreateFunctionCallRecord` (POST request body) and a new `FunctionCallResponse` (`function, args, result, error, timestamp`).

The control API now returns `FunctionCallResponse` from every function-call route instead of serializing the domain record.

## Why

The env snapshots on `FunctionCallRecord` are internal grading state that **no client consumes** — the orchestrator reads only `result`/`function` from the list endpoint, and both SDKs ignore the POST response. Exposing them forced per-route `response_model_exclude` that was applied **inconsistently**: list routes hid the snapshots while GET-by-index and the POST response leaked them. The new DTO makes the contract uniform and decoupled from internal storage.

## Tests

The two tests that probed env snapshots through the API now assert the snapshot/chaining invariant against server-side state (where it lives). 117 tests green.

This is the first of two stacked PRs; the environment-backend / verification-provider seams build on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)