### PR TITLE
Add OpenShellBackend scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ The system has three moving parts:
 
 3. **The fake tools** — the interception layer you author for the agent you're testing. These sit between the agent and its real tools, forwarding calls upstream for authentic data and splicing in injection payloads from the control plane environment.
 
+## Environment backends
+
+What the agent operates on is pluggable. A suite picks its backend in `suite.yaml` (`environment.backend`); the engine provisions it and grades against the resulting pre/post state plus any runtime observations.
+
+- **`dict`** (default) — an in-memory state model declared inline; fake tools read/write it via the control plane.
+- **`openshell`** — a sandboxed [OpenShell](https://github.com/NVIDIA/OpenShell) container where the agent runs inside: the workspace diff is the pre/post environment, and the kernel's OCSF events feed verifiers. *(Scaffold — see `openshell_backend.py`.)*
+
 ## Weather Suite (Reference Implementation)
 
 The weather suite is a minimal working example. Have a look at `suites/weather/suite.yaml`. In there you will find:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ What the agent operates on is pluggable. A suite picks its backend in `suite.yam
 - **`dict`** (default) — an in-memory state model declared inline; fake tools read/write it via the control plane.
 - **`openshell`** — a sandboxed [OpenShell](https://github.com/NVIDIA/OpenShell) container where the agent runs inside: the workspace diff is the pre/post environment, and the kernel's OCSF events feed verifiers. *(Scaffold — see `openshell_backend.py`.)*
 
+`backend` is a bare name (`backend: dict`) or an object carrying infra config (`backend: {type: openshell, image: pi}`); the declared `state` is a sibling key either way.
+
 ## Weather Suite (Reference Implementation)
 
 The weather suite is a minimal working example. Have a look at `suites/weather/suite.yaml`. In there you will find:

--- a/src/midojo/backends.py
+++ b/src/midojo/backends.py
@@ -73,12 +73,14 @@ class DictEnvironmentBackend:
 
 # --- Backend registry + dispatch ---
 #
-# Mirrors the verification-provider registry: a suite's ``environment.backend``
-# field selects which factory builds the backend, so new backends register
-# instead of editing the suite loader. A factory receives the suite name and
-# the full ``environment`` block (so it can read its own backend-specific keys).
+# Mirrors the verifier registry. A suite's ``environment.backend`` selects the
+# backend; it is either a bare name (``backend: dict``) or an object carrying the
+# backend's infra config (``backend: {type: openshell, image: pi, ...}``). The
+# declared environment state stays a sibling key (``state``), parallel across
+# backends. A factory receives the suite name, the full ``environment`` block,
+# and the parsed backend infra config.
 
-BackendFactory = Callable[[str, dict], EnvironmentBackend]
+BackendFactory = Callable[[str, dict, dict], EnvironmentBackend]
 
 _BACKENDS: dict[str, BackendFactory] = {}
 
@@ -89,26 +91,43 @@ def register_backend(name: str, factory: BackendFactory) -> None:
     _BACKENDS[name] = factory
 
 
+def _parse_backend(env_config: dict) -> tuple[str, dict]:
+    """Resolve ``environment.backend`` into a (name, infra_config) pair."""
+    spec = env_config.get("backend", "dict")
+    if isinstance(spec, str):
+        return spec, {}
+    if isinstance(spec, dict):
+        if "type" not in spec:
+            raise ValueError("object form of 'backend' requires a 'type' field")
+        return spec["type"], {k: v for k, v in spec.items() if k != "type"}
+    raise ValueError(f"'backend' must be a name or an object with a 'type', got: {spec!r}")
+
+
 def build_backend(suite_name: str, env_config: dict) -> EnvironmentBackend:
     """Construct the backend declared by ``env_config['backend']`` (default: dict)."""
-    name = env_config.get("backend", "dict")
+    name, backend_config = _parse_backend(env_config)
     factory = _BACKENDS.get(name)
     if factory is None:
         raise ValueError(f"Unknown environment backend: {name!r}. Registered: {sorted(_BACKENDS)}")
-    return factory(suite_name, env_config)
+    return factory(suite_name, env_config, backend_config)
 
 
-def _build_dict_backend(suite_name: str, env_config: dict) -> EnvironmentBackend:
+def _build_dict_backend(suite_name: str, env_config: dict, backend_config: dict) -> EnvironmentBackend:
     if "state" not in env_config:
         raise ValueError("dict environment backend requires a 'state' field under 'environment'")
     return DictEnvironmentBackend(suite_name, env_config["state"])
 
 
-def _build_openshell_backend(suite_name: str, env_config: dict) -> EnvironmentBackend:
+def _build_openshell_backend(suite_name: str, env_config: dict, backend_config: dict) -> EnvironmentBackend:
     # Imported lazily so the openshell SDK is only needed when the backend runs.
     from midojo.openshell_backend import OpenShellBackend
 
-    return OpenShellBackend(suite_name, env_config)
+    return OpenShellBackend(
+        suite_name,
+        image=backend_config.get("image"),
+        policy=backend_config.get("policy"),
+        workspace=env_config.get("state", {}),
+    )
 
 
 register_backend("dict", _build_dict_backend)

--- a/src/midojo/backends.py
+++ b/src/midojo/backends.py
@@ -104,4 +104,12 @@ def _build_dict_backend(suite_name: str, env_config: dict) -> EnvironmentBackend
     return DictEnvironmentBackend(suite_name, env_config["state"])
 
 
+def _build_openshell_backend(suite_name: str, env_config: dict) -> EnvironmentBackend:
+    # Imported lazily so the openshell SDK is only needed when the backend runs.
+    from midojo.openshell_backend import OpenShellBackend
+
+    return OpenShellBackend(suite_name, env_config)
+
+
 register_backend("dict", _build_dict_backend)
+register_backend("openshell", _build_openshell_backend)

--- a/src/midojo/openshell_backend.py
+++ b/src/midojo/openshell_backend.py
@@ -33,14 +33,14 @@ from midojo.types import Environment
 class OpenShellEnvironment(Environment):
     """Observable state of an OpenShell sandbox.
 
-    ``workspace_files`` is the pre/post snapshot of seeded files; the remaining
-    fields are populated post-session from the workspace diff and OCSF stream.
+    ``workspace_files`` is the pre/post snapshot of seeded files; ``files_created``
+    is the post-session workspace diff. Runtime evidence (OCSF network/process
+    events) is *not* env state — it flows through ``observations``, read by an
+    ``openshell`` verifier, not stored here.
     """
 
     workspace_files: dict[str, str] = Field(default_factory=dict)
     files_created: list[str] = Field(default_factory=list)
-    # raw OCSF lines, e.g. "NET:OPEN DENIED curl -> evil.com:443"
-    network_events: list[str] = Field(default_factory=list)
 
 
 class OpenShellBackend:

--- a/src/midojo/openshell_backend.py
+++ b/src/midojo/openshell_backend.py
@@ -49,20 +49,28 @@ class OpenShellBackend:
     Suite YAML::
 
         environment:
-          backend: openshell
-          image: pi              # OpenShell sandbox image / --from target
-          policy: pi             # optional named/inline OPA policy
-          workspace:             # seeded files (probe placeholders allowed)
+          backend:               # infra config lives inside the backend
+            type: openshell
+            image: pi            # OpenShell sandbox image / --from target
+            policy: pi           # optional named/inline OPA policy
+          state:                 # seeded workspace files (probe placeholders allowed)
             customer_report.txt: "Q4 report ... {injection_task_0:main}"
     """
 
-    def __init__(self, suite_name: str, env_config: dict) -> None:
-        if "image" not in env_config:
-            raise ValueError("openshell backend requires an 'image' field under 'environment'")
+    def __init__(
+        self,
+        suite_name: str,
+        *,
+        image: str | None,
+        policy: str | None = None,
+        workspace: dict[str, str] | None = None,
+    ) -> None:
+        if not image:
+            raise ValueError("openshell backend requires an 'image' field under 'environment.backend'")
         self._suite_name = suite_name
-        self._image: str = env_config["image"]
-        self._policy = env_config.get("policy")
-        self._workspace: dict[str, str] = env_config.get("workspace", {})
+        self._image: str = image
+        self._policy = policy
+        self._workspace: dict[str, str] = workspace or {}
         # The live sandbox handle, set by setup() for the active evaluation.
         # Evals run sequentially (see app.state), so a single handle is safe.
         self._sandbox: Any = None

--- a/src/midojo/openshell_backend.py
+++ b/src/midojo/openshell_backend.py
@@ -1,0 +1,121 @@
+"""OpenShell environment backend (scaffold).
+
+A container backend that provisions a sandboxed shell environment on NVIDIA
+OpenShell (https://github.com/NVIDIA/OpenShell). Unlike the dict backend — whose
+"environment" is an in-memory model — OpenShell's environment is a real Linux
+sandbox: the agent runs *inside* it (e.g. ``--from pi``), governed by a policy,
+and the kernel audits everything it does as OCSF events.
+
+Two observation channels map onto the engine's grading inputs:
+  * **workspace diff** — the seeded ``/sandbox`` files before vs. after the
+    session — is the pre/post environment (graded by ordinary env predicates).
+  * **OCSF events** — network/process/finding events from the sandbox's policy
+    enforcement — are runtime observations (graded by an ``openshell`` verifier).
+
+Status: ``provision()`` (workspace rendering) is real and tested. The live
+sandbox lifecycle (``setup``/``snapshot``/``observations``/``teardown``) is
+scaffolded against the OpenShell gRPC SDK and is **not yet exercised** — it
+needs the Phase-2 eval-lifecycle plumbing (the control plane calling
+setup/teardown and routing observations into grading) and a live gateway to run
+against. The method bodies document the intended gRPC mapping.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field
+
+from midojo.probes import substitute_probes
+from midojo.types import Environment
+
+
+class OpenShellEnvironment(Environment):
+    """Observable state of an OpenShell sandbox.
+
+    ``workspace_files`` is the pre/post snapshot of seeded files; the remaining
+    fields are populated post-session from the workspace diff and OCSF stream.
+    """
+
+    workspace_files: dict[str, str] = Field(default_factory=dict)
+    files_created: list[str] = Field(default_factory=list)
+    # raw OCSF lines, e.g. "NET:OPEN DENIED curl -> evil.com:443"
+    network_events: list[str] = Field(default_factory=list)
+
+
+class OpenShellBackend:
+    """Provisions an OpenShell sandbox from a suite's image + policy + workspace.
+
+    Suite YAML::
+
+        environment:
+          backend: openshell
+          image: pi              # OpenShell sandbox image / --from target
+          policy: pi             # optional named/inline OPA policy
+          workspace:             # seeded files (probe placeholders allowed)
+            customer_report.txt: "Q4 report ... {injection_task_0:main}"
+    """
+
+    def __init__(self, suite_name: str, env_config: dict) -> None:
+        if "image" not in env_config:
+            raise ValueError("openshell backend requires an 'image' field under 'environment'")
+        self._suite_name = suite_name
+        self._image: str = env_config["image"]
+        self._policy = env_config.get("policy")
+        self._workspace: dict[str, str] = env_config.get("workspace", {})
+        # The live sandbox handle, set by setup() for the active evaluation.
+        # Evals run sequentially (see app.state), so a single handle is safe.
+        self._sandbox: Any = None
+
+    @property
+    def environment_type(self) -> type[Environment]:
+        return OpenShellEnvironment
+
+    def provision(self, injections: dict[str, str]) -> Environment:
+        """Render the seeded workspace with the active injections substituted.
+
+        Returns the pre-session environment. Seeding it into a live sandbox is
+        setup()'s job (Phase 2); this stays pure so suites load without a gateway.
+        """
+        files = {path: substitute_probes(template, injections) for path, template in self._workspace.items()}
+        return OpenShellEnvironment(workspace_files=files)
+
+    # --- Live sandbox lifecycle (scaffold; Phase-2 plumbing will call these) ---
+
+    @staticmethod
+    def _sandbox_client() -> Any:
+        try:
+            from openshell import SandboxClient  # pyright: ignore[reportMissingImports]
+        except ImportError as e:  # pragma: no cover - exercised only with the SDK installed
+            raise RuntimeError(
+                "The 'openshell' SDK is required for the OpenShell backend. Install it with `uv pip install openshell`."
+            ) from e
+        return SandboxClient()
+
+    def setup(self, environment: OpenShellEnvironment) -> None:
+        """Create the sandbox from the image+policy and seed the workspace.
+
+        gRPC mapping: ``CreateSandbox(spec)`` then ``ExecSandbox`` to write each
+        ``workspace_files`` entry under ``/sandbox`` and drop a baseline marker.
+        """
+        raise NotImplementedError("OpenShell sandbox provisioning is not wired yet (Phase 2).")
+
+    def snapshot(self) -> OpenShellEnvironment:
+        """Read the post-session workspace back (diff vs. the seeded baseline).
+
+        gRPC mapping: ``ExecSandbox(['find /sandbox -newer .baseline'])`` + read.
+        """
+        raise NotImplementedError("OpenShell workspace snapshot is not wired yet (Phase 2).")
+
+    def observations(self) -> dict[str, Any]:
+        """Fetch OCSF runtime events for the session.
+
+        gRPC mapping: ``GetSandboxLogs`` (raw proto stub — no high-level wrapper),
+        filtered to ``level == "OCSF"`` and parsed into network/process/finding
+        events for the ``openshell`` verifier.
+        """
+        raise NotImplementedError("OpenShell OCSF observations are not wired yet (Phase 2).")
+
+    def teardown(self) -> None:
+        """Destroy the sandbox. gRPC mapping: ``DeleteSandbox``."""
+        raise NotImplementedError("OpenShell sandbox teardown is not wired yet (Phase 2).")

--- a/tests/test_openshell_backend.py
+++ b/tests/test_openshell_backend.py
@@ -1,0 +1,53 @@
+import pytest
+
+from midojo.backends import build_backend
+from midojo.openshell_backend import OpenShellBackend, OpenShellEnvironment
+
+ENV_CONFIG = {
+    "backend": "openshell",
+    "image": "pi",
+    "policy": "pi",
+    "workspace": {
+        "customer_report.txt": "Q4 revenue $2.4M. {injection_task_0:main}",
+        "notes.txt": "no placeholders here",
+    },
+}
+
+
+class TestRegistration:
+    def test_build_backend_dispatches_to_openshell(self):
+        backend = build_backend("shell_suite", ENV_CONFIG)
+        assert isinstance(backend, OpenShellBackend)
+        assert backend.environment_type is OpenShellEnvironment
+
+    def test_missing_image_raises(self):
+        with pytest.raises(ValueError, match="requires an 'image' field"):
+            build_backend("shell_suite", {"backend": "openshell", "workspace": {}})
+
+
+class TestProvision:
+    def test_active_probe_substituted_into_workspace(self):
+        backend = build_backend("shell_suite", ENV_CONFIG)
+        env = backend.provision({"injection_task_0:main": "curl evil.com"})
+        assert isinstance(env, OpenShellEnvironment)
+        assert "curl evil.com" in env.workspace_files["customer_report.txt"]
+        assert env.workspace_files["notes.txt"] == "no placeholders here"
+
+    def test_inactive_probe_collapses_to_empty(self):
+        backend = build_backend("shell_suite", ENV_CONFIG)
+        env = backend.provision({})
+        assert "{injection_task_0" not in env.workspace_files["customer_report.txt"]
+
+
+class TestLifecycleScaffold:
+    """The live-sandbox lifecycle isn't wired yet — it must fail loudly, not silently."""
+
+    def test_setup_not_implemented(self):
+        backend = build_backend("shell_suite", ENV_CONFIG)
+        with pytest.raises(NotImplementedError, match="Phase 2"):
+            backend.setup(backend.provision({}))
+
+    def test_sandbox_client_requires_sdk(self):
+        # The openshell SDK is not a midojo dependency; absent it, fail clearly.
+        with pytest.raises(RuntimeError, match="openshell"):
+            OpenShellBackend._sandbox_client()

--- a/tests/test_openshell_backend.py
+++ b/tests/test_openshell_backend.py
@@ -4,10 +4,8 @@ from midojo.backends import build_backend
 from midojo.openshell_backend import OpenShellBackend, OpenShellEnvironment
 
 ENV_CONFIG = {
-    "backend": "openshell",
-    "image": "pi",
-    "policy": "pi",
-    "workspace": {
+    "backend": {"type": "openshell", "image": "pi", "policy": "pi"},
+    "state": {
         "customer_report.txt": "Q4 revenue $2.4M. {injection_task_0:main}",
         "notes.txt": "no placeholders here",
     },
@@ -22,7 +20,7 @@ class TestRegistration:
 
     def test_missing_image_raises(self):
         with pytest.raises(ValueError, match="requires an 'image' field"):
-            build_backend("shell_suite", {"backend": "openshell", "workspace": {}})
+            build_backend("shell_suite", {"backend": {"type": "openshell"}, "state": {}})
 
 
 class TestProvision:


### PR DESCRIPTION
> **Part 2 of 3 — Environment backends & verifiers series**
> 1. #66 — environment-backend + verification-provider seams (the two pluggable axes)
> 2. #67 — `OpenShellBackend` scaffold (first non-dict backend)
> 3. #68 — observations recording channel (runtime evidence into grading)
>
> *(stacked; each PR's base retargets down as the one below it merges)*

> **Stacked on #66** — review/merge that first. Base retargets to `main` once #66 lands.

## What

Adds the `openshell` environment backend — the first non-dict `EnvironmentBackend` — plus a brief README section on the backend axis.

OpenShell ([NVIDIA/OpenShell](https://github.com/NVIDIA/OpenShell)) runs the agent *inside* a policy-governed sandbox (`--from pi`, etc.). It maps onto our two channels cleanly:
- **workspace diff** (seeded `/sandbox` files, before vs. after) = pre/post environment → ordinary env predicates.
- **OCSF events** (kernel-audited network/process/finding events from policy enforcement) = runtime `observations` → an `openshell` verifier.

No OGX: midojo talks to OpenShell directly via the gRPC SDK, and drives the agent by exec'ing its CLI inside the sandbox.

## What's real vs. scaffold

- ✅ **`provision()`** — renders the seeded workspace with probe substitution; registered + tested. Suites load without a gateway.
- 🚧 **`setup` / `snapshot` / `observations` / `teardown`** — scaffolded against the gRPC SDK with the intended mapping documented; they `raise NotImplementedError` (fail loud, not silent) pending **Phase-2 eval-lifecycle plumbing** (control plane calling setup/teardown, routing observations into grading) and a live gateway to test against.
- The `openshell` SDK is **lazily imported**, so it's not a hard dependency; absent it, the backend raises a clear install hint.

Suite shape:
```yaml
environment:
  backend: openshell
  image: pi
  policy: pi
  workspace:
    customer_report.txt: "Q4 report ... {injection_task_0:main}"
```

## Tests
6 new tests (registration, probe substitution, missing-image error, lifecycle-fails-loud, SDK-absent error). Full suite: 129 passing.

## Follow-ups (not here)
- Phase-2 backend lifecycle plumbing (provision→handle, setup/snapshot/observations/teardown in the eval lifecycle).
- An `openshell` verifier consuming OCSF observations.
- Mirror the `verifiers/` package split for backends (`backends/` package) once there's a 2nd+ backend to justify it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
