### PR TITLE
Fix OGX protocol: NameError on startup + hardcoded MCP server label

### DIFF
--- a/src/midojo/agent_client.py
+++ b/src/midojo/agent_client.py
@@ -101,6 +101,7 @@ class OGXResponsesClient(AgentClient):
         model: str,
         mcp_server_url: str,
         *,
+        mcp_server_label: str = "midojo",
         instructions: str = "",
         shield_id: str | None = None,
         timeout: float = 120.0,
@@ -108,6 +109,7 @@ class OGXResponsesClient(AgentClient):
         self.ogx_url = ogx_url
         self.model = model
         self.mcp_server_url = mcp_server_url
+        self.mcp_server_label = mcp_server_label
         self.instructions = instructions
         self.shield_id = shield_id
         self.timeout = timeout
@@ -123,7 +125,7 @@ class OGXResponsesClient(AgentClient):
             tools=[
                 {
                     "type": "mcp",
-                    "server_label": "weather",
+                    "server_label": self.mcp_server_label,
                     "server_url": self.mcp_server_url,
                     "require_approval": "never",
                 },

--- a/src/midojo/orchestrator.py
+++ b/src/midojo/orchestrator.py
@@ -324,6 +324,7 @@ def main(
             ogx_url=agent_url,
             model=ogx_model or os.environ.get("OGX_MODEL", "litellm/llama-scout-17b"),
             mcp_server_url=os.environ.get("MCP_SERVER_URL", "http://localhost:8081/mcp"),
+            mcp_server_label=suite_name,
             instructions=system_message,
             shield_id=ogx_shield,
         )

--- a/src/midojo/orchestrator.py
+++ b/src/midojo/orchestrator.py
@@ -293,6 +293,11 @@ async def run_benchmark(
 @click.option(
     "--ogx-shield", default=None, envvar="OGX_SHIELD_ID", help="Shield ID for OGX guardrails (ogx protocol only)."
 )
+@click.option(
+    "--mcp-server-label", default=None, envvar="MCP_SERVER_LABEL",
+    help="Label the MCP server is registered under on the agent's inference server. "
+         "Defaults to the suite name. Override when the server expects a different label.",
+)
 def main(
     control_url: str,
     agent_url: str,
@@ -304,6 +309,7 @@ def main(
     protocol: str,
     ogx_model: str | None,
     ogx_shield: str | None,
+    mcp_server_label: str | None,
 ) -> None:
     for module in modules_to_load:
         importlib.import_module(module)
@@ -324,7 +330,7 @@ def main(
             ogx_url=agent_url,
             model=ogx_model or os.environ.get("OGX_MODEL", "litellm/llama-scout-17b"),
             mcp_server_url=os.environ.get("MCP_SERVER_URL", "http://localhost:8081/mcp"),
-            mcp_server_label=suite_name,
+            mcp_server_label=mcp_server_label or suite_name,
             instructions=system_message,
             shield_id=ogx_shield,
         )

--- a/src/midojo/orchestrator.py
+++ b/src/midojo/orchestrator.py
@@ -315,7 +315,11 @@ def main(
     elif protocol == "pi":
         agent_client = PIAgentClient(agent_url, control_url)
     elif protocol == "ogx":
-        system_message = getattr(suite_module, "SYSTEM_MESSAGE", "")
+        try:
+            _suite_mod = importlib.import_module(f"suites.{suite_name}")
+        except ImportError:
+            _suite_mod = None
+        system_message = getattr(_suite_mod, "SYSTEM_MESSAGE", "")
         agent_client = OGXResponsesClient(
             ogx_url=agent_url,
             model=ogx_model or os.environ.get("OGX_MODEL", "litellm/llama-scout-17b"),

--- a/tests/test_agent_client.py
+++ b/tests/test_agent_client.py
@@ -1,0 +1,53 @@
+"""Tests for agent client implementations."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from midojo.agent_client import OGXResponsesClient
+
+
+class TestOGXResponsesClient:
+    """Tests for the OGX protocol client fixes."""
+
+    def test_mcp_server_label_stored(self):
+        """mcp_server_label is stored and not hardcoded to 'weather'."""
+        client = OGXResponsesClient(
+            ogx_url="http://localhost:8321",
+            model="llama-scout-17b",
+            mcp_server_url="http://localhost:8082/mcp",
+            mcp_server_label="minibank",
+        )
+        assert client.mcp_server_label == "minibank"
+
+    def test_mcp_server_label_default(self):
+        """mcp_server_label defaults to 'midojo' when not given."""
+        client = OGXResponsesClient(
+            ogx_url="http://localhost:8321",
+            model="llama-scout-17b",
+            mcp_server_url="http://localhost:8082/mcp",
+        )
+        assert client.mcp_server_label == "midojo"
+
+    def test_suite_module_import_missing(self):
+        """Protocol dispatch: missing suite module falls back to empty SYSTEM_MESSAGE."""
+        try:
+            _suite_mod = importlib.import_module("suites.nonexistent_suite_xyz")
+        except ImportError:
+            _suite_mod = None
+        system_message = getattr(_suite_mod, "SYSTEM_MESSAGE", "")
+        assert system_message == ""
+
+    def test_suite_module_import_no_system_message(self):
+        """Protocol dispatch: suite module without SYSTEM_MESSAGE falls back to empty."""
+        # The weather suite's __init__.py may or may not define SYSTEM_MESSAGE;
+        # the fallback must always work regardless.
+        try:
+            _suite_mod = importlib.import_module("suites.weather")
+        except ImportError:
+            _suite_mod = None
+        # getattr with default must not raise even if attribute is absent
+        system_message = getattr(_suite_mod, "SYSTEM_MESSAGE", "")
+        assert isinstance(system_message, str)

--- a/tests/test_agent_client.py
+++ b/tests/test_agent_client.py
@@ -31,6 +31,16 @@ class TestOGXResponsesClient:
         )
         assert client.mcp_server_label == "midojo"
 
+    def test_mcp_server_label_override(self):
+        """mcp_server_label can be overridden from suite_name default."""
+        client = OGXResponsesClient(
+            ogx_url="http://localhost:8321",
+            model="llama-scout-17b",
+            mcp_server_url="http://localhost:8082/mcp",
+            mcp_server_label="my-custom-label",
+        )
+        assert client.mcp_server_label == "my-custom-label"
+
     def test_suite_module_import_missing(self):
         """Protocol dispatch: missing suite module falls back to empty SYSTEM_MESSAGE."""
         try:


### PR DESCRIPTION
## Two bug fixes in `--protocol ogx`

### Bug 1: NameError on startup
**Fixes: [RHOAIENG-72189](https://redhat.atlassian.net/browse/RHOAIENG-72189)**

`suite_module` was referenced but never defined in the `ogx` branch of the protocol dispatch. Any invocation with `--protocol ogx` raised immediately:

```
NameError: name 'suite_module' is not defined
```

**Fix:** Import the suite's Python module inline to retrieve `SYSTEM_MESSAGE`, falling back to `""` if the module doesn't exist or doesn't define it.

---

### Bug 2: Hardcoded `'weather'` MCP server label
**Partially addresses: [RHOAIENG-72173](https://redhat.atlassian.net/browse/RHOAIENG-72173)**

The `server_label` in the MCP tools spec was hardcoded to `"weather"`. Llama Stack uses this label to identify the MCP tool source in its routing table, so running any non-weather suite with `--protocol ogx` would mislabel the tool server.

**Fix:** Exposed as `mcp_server_label` parameter on `OGXResponsesClient`, defaulting to `suite_name` passed from the orchestrator.

---

## Verification

- Reproduced the `NameError` on `main`, confirmed it's gone after the fix
- Confirmed the OGX client connects end-to-end to a live server at `localhost:8321` (tested with `ollama/qwen3.5:2b`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)