### PR TITLE
Fix minibank cluster deployment: readiness probe + garak_hijack rung

### DIFF
--- a/suites/minibank/deploy/agent.yaml
+++ b/suites/minibank/deploy/agent.yaml
@@ -35,8 +35,7 @@ spec:
           ports:
             - containerPort: 8000
           readinessProbe:
-            httpGet:
-              path: /.well-known/agent-card.json
+            tcpSocket:
               port: 8000
             initialDelaySeconds: 5
             periodSeconds: 5

--- a/suites/minibank/deploy/run-ladder.job.yaml
+++ b/suites/minibank/deploy/run-ladder.job.yaml
@@ -38,7 +38,7 @@ spec:
                 --protocol a2a \
                 --suite minibank \
                 -ut user_task_1 \
-                -it ladder_a -it ladder_b -it ladder_c \
+                -it ladder_a -it ladder_b -it ladder_c -it garak_hijack \
                 --logdir /tmp/runs
           resources:
             requests:


### PR DESCRIPTION
completes [RHOAIENG-72267](https://redhat.atlassian.net/browse/RHOAIENG-72267)

## Summary

Two fixes discovered during end-to-end validation on a ROSA HCP cluster (RHOAIENG-72267).

**Fix 1 — `agent.yaml`: switch readiness probe from `httpGet` to `tcpSocket`**

The `httpGet` probe hits `/.well-known/agent-card.json` every 5s. When the agent is processing a slow LLM call (30-60s on a real model), the probe gets no response, the pod is marked Not Ready, and the Service removes it from its endpoints — causing the orchestrator Job to lose connectivity mid-run. Switching to `tcpSocket` checks only that the port is bound, which stays true throughout the LLM call.

**Fix 2 — `run-ladder.job.yaml`: add `-it garak_hijack`**

The `garak_hijack` rung was added in PR #92 after the deploy manifests were written. It was missing from the cluster Job.

## Test plan

- [x] Validated end-to-end on ROSA HCP cluster ([RHOAIENG-72267](https://redhat.atlassian.net/browse/RHOAIENG-72267))

🤖 Generated with [Claude Code](https://claude.com/claude-code)