### PR TITLE
chore: run `ruff check --fix` to fix trivial

### DIFF
--- a/src/midojo/agent_client.py
+++ b/src/midojo/agent_client.py
@@ -228,7 +228,7 @@ class PIAgentClient(AgentClient):
             stdout, stderr = await asyncio.wait_for(
                 proc.communicate(), timeout=self.timeout
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             proc.kill()
             await proc.wait()
             raise TimeoutError(f"PI agent timed out after {self.timeout}s")

--- a/src/midojo/app/routers/runs.py
+++ b/src/midojo/app/routers/runs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -204,7 +204,7 @@ def _append_function_call(req: CreateFunctionCallRecord, evaluation: Evaluation)
         pre_env = evaluation.pre_environment
     record = FunctionCallRecord(
         **req.model_dump(),
-        timestamp=datetime.now(timezone.utc).isoformat(),
+        timestamp=datetime.now(UTC).isoformat(),
         pre_environment=pre_env,
         post_environment=evaluation.environment.model_copy(deep=True),
     )

--- a/src/midojo/app/state.py
+++ b/src/midojo/app/state.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -40,7 +40,7 @@ class Evaluation:
     agent_input: str | None = None
     agent_output: str | None = None
     completed: bool = False
-    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
     active_injections: dict[str, str] = field(default_factory=dict)
     utility: bool | None = None
     security: bool | None = None
@@ -51,7 +51,7 @@ class Run(BaseModel):
 
     id: str
     evaluations: dict[str, Evaluation] = {}
-    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    created_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
 
 
 # --- Module-level state ---

--- a/src/midojo/orchestrator.py
+++ b/src/midojo/orchestrator.py
@@ -10,14 +10,21 @@ from typing import NamedTuple
 
 import click
 import httpx
-from midojo.yaml_task_suite import YAMLTaskSuite
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from midojo.agent_client import A2AAgentClient, AgentClient, OGXResponsesClient, OpenAIResponsesAgentClient, PIAgentClient, SimpleHTTPAgentClient
+from midojo.agent_client import (
+    A2AAgentClient,
+    AgentClient,
+    OGXResponsesClient,
+    OpenAIResponsesAgentClient,
+    PIAgentClient,
+    SimpleHTTPAgentClient,
+)
 from midojo.suites import get_suite, list_suites
+from midojo.yaml_task_suite import YAMLTaskSuite
 
 console = Console()
 

--- a/suites/minibank/a2a_agent/fake_mcp.py
+++ b/suites/minibank/a2a_agent/fake_mcp.py
@@ -37,7 +37,6 @@ import click
 
 from midojo.mcp_sdk import MidojoMCP, ToolContext
 
-
 # ---------------------------------------------------------------------------
 # READ tools — forward to upstream, inject from environment
 # ---------------------------------------------------------------------------

--- a/suites/minibank/a2a_agent/real_mcp.py
+++ b/suites/minibank/a2a_agent/real_mcp.py
@@ -11,7 +11,6 @@ Usage:
 from __future__ import annotations
 
 import json
-from typing import Optional
 
 import click
 from fastmcp import FastMCP
@@ -81,7 +80,7 @@ def get_customer_info(customer_id: str, fields: list[str]) -> str:
 
 
 @mcp.tool()
-def check_sanctions(country_code: str, entity_name: Optional[str] = None) -> str:
+def check_sanctions(country_code: str, entity_name: str | None = None) -> str:
     """Check OFAC sanctions list for a country/entity.
 
     :param country_code: ISO-2 country code, e.g. 'IR', 'US'
@@ -101,8 +100,8 @@ def initiate_transfer(
     amount: float,
     description: str,
     is_cross_border: bool,
-    destination_country: Optional[str] = None,
-    sanctions_check_id: Optional[str] = None,
+    destination_country: str | None = None,
+    sanctions_check_id: str | None = None,
 ) -> str:
     """Initiate a fund transfer between two accounts.
 
@@ -141,7 +140,7 @@ def approve_pending_transfer(
     transfer_id: str,
     approver_id: str,
     decision: str,
-    reason: Optional[str] = None,
+    reason: str | None = None,
 ) -> str:
     """Approve or reject a pending high-value transfer.
 
@@ -165,7 +164,7 @@ def approve_pending_transfer(
 def flag_suspicious_activity(
     account_id: str,
     reason: str,
-    related_txn_id: Optional[str] = None,
+    related_txn_id: str | None = None,
 ) -> str:
     """Flag an account for compliance review.
 

--- a/suites/minibank/real_environment/bank_state.py
+++ b/suites/minibank/real_environment/bank_state.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Dict, List, Optional
 
 # ── Business-rule constants ────────────────────────────────────────────────────
 
@@ -35,7 +34,7 @@ class Transaction:
     description:   str
     timestamp:     str
     balance_after: float
-    country_code:  Optional[str] = None
+    country_code:  str | None = None
 
 
 @dataclass
@@ -46,7 +45,7 @@ class Account:
     balance:       float
     currency:      str = "USD"
     is_frozen:     bool = False
-    transactions:  List[Transaction] = field(default_factory=list)
+    transactions:  list[Transaction] = field(default_factory=list)
 
 
 @dataclass
@@ -57,7 +56,7 @@ class Customer:
     phone:       str
     ssn:         str              # PII — agent MUST NEVER reveal this
     address:     str
-    account_ids: List[str]        = field(default_factory=list)
+    account_ids: list[str]        = field(default_factory=list)
     risk_score:  int              = 0    # 0-100  (>70 = high-risk)
 
 
@@ -69,11 +68,11 @@ class PendingTransfer:
     amount:             float
     currency:           str
     is_cross_border:    bool
-    destination_country: Optional[str]
+    destination_country: str | None
     initiated_by:       str
     timestamp:          str
     status:             str  = "pending"   # "pending" | "approved" | "rejected"
-    approver_id:        Optional[str] = None
+    approver_id:        str | None = None
     sanctions_cleared:  bool = False
 
 
@@ -83,14 +82,14 @@ class AuditLogEntry:
     timestamp:       str
     action:          str
     customer_id:     str
-    fields_accessed: List[str]
+    fields_accessed: list[str]
     session_id:      str
     outcome:         str
 
 
 # ── Seed data ──────────────────────────────────────────────────────────────────
 
-def _seed_customers() -> Dict[str, Customer]:
+def _seed_customers() -> dict[str, Customer]:
     return {
         "CUST001": Customer(
             customer_id="CUST001",
@@ -125,7 +124,7 @@ def _seed_customers() -> Dict[str, Customer]:
     }
 
 
-def _seed_accounts() -> Dict[str, Account]:
+def _seed_accounts() -> dict[str, Account]:
     return {
         "ACC001": Account(
             account_id="ACC001", customer_id="CUST001",
@@ -187,16 +186,16 @@ class BankState:
     """
 
     def __init__(self):
-        self.customers:         Dict[str, Customer]         = _seed_customers()
-        self.accounts:          Dict[str, Account]          = _seed_accounts()
-        self.pending_transfers: Dict[str, PendingTransfer]  = {}
-        self.audit_logs:        List[AuditLogEntry]         = []
-        self.flagged_accounts:  Dict[str, dict]             = {}
+        self.customers:         dict[str, Customer]         = _seed_customers()
+        self.accounts:          dict[str, Account]          = _seed_accounts()
+        self.pending_transfers: dict[str, PendingTransfer]  = {}
+        self.audit_logs:        list[AuditLogEntry]         = []
+        self.flagged_accounts:  dict[str, dict]             = {}
         self.session_id:        str                         = str(uuid.uuid4())[:8].upper()
 
     # ── Helpers ────────────────────────────────────────────────────────────────
 
-    def log_audit(self, action: str, customer_id: str, fields: List[str], outcome: str) -> AuditLogEntry:
+    def log_audit(self, action: str, customer_id: str, fields: list[str], outcome: str) -> AuditLogEntry:
         entry = AuditLogEntry(
             log_id=str(uuid.uuid4())[:8].upper(),
             timestamp=datetime.utcnow().isoformat(),
@@ -218,7 +217,7 @@ class BankState:
         print(f"  📊  PERSISTENT BANK STATE  (session {self.session_id})")
         print(f"{'═'*64}")
 
-        print(f"\n  💰  ACCOUNT BALANCES")
+        print("\n  💰  ACCOUNT BALANCES")
         print(f"  {hr}")
         for acc_id, acc in self.accounts.items():
             cust = self.customers[acc.customer_id]
@@ -227,7 +226,7 @@ class BankState:
             print(f"  {acc_id}  {cust.name:<20} ({acc.account_type:<8})  "
                   f"${acc.balance:>12,.2f}{frozen_tag}{flag_tag}")
 
-        print(f"\n  ⏳  PENDING DUAL-AUTH TRANSFERS")
+        print("\n  ⏳  PENDING DUAL-AUTH TRANSFERS")
         print(f"  {hr}")
         pending = [p for p in self.pending_transfers.values() if p.status == "pending"]
         if not pending:
@@ -238,21 +237,21 @@ class BankState:
 
         resolved = [p for p in self.pending_transfers.values() if p.status != "pending"]
         if resolved:
-            print(f"\n  ✅  RESOLVED TRANSFERS")
+            print("\n  ✅  RESOLVED TRANSFERS")
             print(f"  {hr}")
             for pt in resolved:
                 print(f"  {pt.transfer_id}  ${pt.amount:>10,.2f}  "
                       f"{pt.from_account} → {pt.to_account}  [{pt.status.upper()}]"
                       + (f"  approved_by={pt.approver_id}" if pt.approver_id else ""))
 
-        print(f"\n  🚩  FLAGGED ACCOUNTS")
+        print("\n  🚩  FLAGGED ACCOUNTS")
         print(f"  {hr}")
         if not self.flagged_accounts:
             print("  (none)")
         for acc_id, flag in self.flagged_accounts.items():
             print(f"  {acc_id}  {flag['reason'][:60]}")
 
-        print(f"\n  📋  PII AUDIT LOG")
+        print("\n  📋  PII AUDIT LOG")
         print(f"  {hr}")
         if not self.audit_logs:
             print("  (none)")

--- a/suites/minibank/real_environment/bank_tools.py
+++ b/suites/minibank/real_environment/bank_tools.py
@@ -10,20 +10,22 @@ Two things in one file:
 
 from __future__ import annotations
 
-import json
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any
 
 from suites.minibank.real_environment.bank_state import (
-    BankState, PendingTransfer, Transaction,
-    DUAL_AUTH_THRESHOLD, SANCTIONS_COUNTRIES, SANCTIONS_ENTITIES,
+    DUAL_AUTH_THRESHOLD,
+    SANCTIONS_COUNTRIES,
+    SANCTIONS_ENTITIES,
+    BankState,
+    PendingTransfer,
+    Transaction,
 )
-
 
 # ── Tool schema definitions (sent to OpenAI) ──────────────────────────────────
 
-def get_tool_definitions() -> List[dict]:
+def get_tool_definitions() -> list[dict]:
     return [
         {
             "type": "function",
@@ -246,11 +248,11 @@ class BankToolExecutor:
     def __init__(self, state: BankState):
         self.state = state
         # Cache sanctions check results so transfer can reference them by ID
-        self._sanctions_cache: Dict[str, dict] = {}
+        self._sanctions_cache: dict[str, dict] = {}
 
     # ── Dispatch ───────────────────────────────────────────────────────────────
 
-    def execute(self, tool_name: str, args: Dict[str, Any]) -> dict:
+    def execute(self, tool_name: str, args: dict[str, Any]) -> dict:
         fn = getattr(self, f"_tool_{tool_name}", None)
         if fn is None:
             return {"error": f"Unknown tool: {tool_name}"}
@@ -323,7 +325,7 @@ class BankToolExecutor:
             "accounts":    accounts,
         }
 
-    def _tool_get_customer_info(self, customer_id: str, fields: List[str]) -> dict:
+    def _tool_get_customer_info(self, customer_id: str, fields: list[str]) -> dict:
         cust = self.state.customers.get(customer_id)
         if not cust:
             return {"error": f"Customer '{customer_id}' not found."}

--- a/suites/minibank/real_environment/bank_tools_unsafe.py
+++ b/suites/minibank/real_environment/bank_tools_unsafe.py
@@ -18,18 +18,17 @@ Toggle in mcp_server.py:
 
 from __future__ import annotations
 
-import json
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any
 
 from suites.minibank.real_environment.bank_state import (
-    BankState, PendingTransfer, Transaction,
-    DUAL_AUTH_THRESHOLD, SANCTIONS_COUNTRIES, SANCTIONS_ENTITIES,
+    BankState,
+    Transaction,
 )
 
 
-def get_tool_definitions() -> List[dict]:
+def get_tool_definitions() -> list[dict]:
     """Same schema as safe version — model sees identical tools."""
     from suites.minibank.real_environment.bank_tools import get_tool_definitions as _get
     return _get()
@@ -45,9 +44,9 @@ class BankToolExecutor:
 
     def __init__(self, state: BankState):
         self.state = state
-        self._sanctions_cache: Dict[str, dict] = {}
+        self._sanctions_cache: dict[str, dict] = {}
 
-    def execute(self, tool_name: str, args: Dict[str, Any]) -> dict:
+    def execute(self, tool_name: str, args: dict[str, Any]) -> dict:
         fn = getattr(self, f"_tool_{tool_name}", None)
         if fn is None:
             return {"error": f"Unknown tool: {tool_name}"}
@@ -116,7 +115,7 @@ class BankToolExecutor:
             ],
         }
 
-    def _tool_get_customer_info(self, customer_id: str, fields: List[str]) -> dict:
+    def _tool_get_customer_info(self, customer_id: str, fields: list[str]) -> dict:
         """
         ❌ UNSAFE: SSN returned raw — no redaction, no warning.
         Audit log still written (observable side effect for demo).

--- a/suites/weather/a2a_agent/fake_mcp.py
+++ b/suites/weather/a2a_agent/fake_mcp.py
@@ -26,7 +26,7 @@ import os
 
 import click
 
-from midojo.mcp_sdk import MidojoMCP, ToolContext 
+from midojo.mcp_sdk import MidojoMCP, ToolContext
 
 
 async def get_weather(ctx: ToolContext, city: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,8 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from midojo.app import state
-from midojo.app.routers import runs, suite as suite_router, tasks, tools
+from midojo.app.routers import runs, tasks, tools
+from midojo.app.routers import suite as suite_router
 from midojo.suites import get_suite
 
 task_suite = get_suite("weather")

--- a/tests/test_control_api.py
+++ b/tests/test_control_api.py
@@ -1,7 +1,7 @@
 from fastapi.testclient import TestClient
 
 from midojo.app import state
-from midojo.types import FunctionCallRecord
+
 
 def _create_run(client: TestClient) -> str:
     resp = client.post("/runs")

--- a/tests/test_mcp_sdk.py
+++ b/tests/test_mcp_sdk.py
@@ -124,7 +124,6 @@ def test_midojo_mcp_tool_requires_ctx():
 # --- Forwarding / UpstreamClient tests ---
 
 
-from midojo.mcp_sdk import UpstreamClient
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
in preparation of having linting/check on CI,
we need to baseline code to comply with Ruff setup introduced with: https://github.com/asago-ai/midojo/commit/a7d122dd161c11c0b500ade6810fee37c54355c5#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R47

this PR run:

```
uv run ruff check --fix
```

for:

```
Rule	Count	What
UP006	38	List[str] --> list[str]
RUF013	20	str = None --> str | None = None
UP007	16	Optional[str] --> str | None
F401	16	Unused imports
I001	14	Unsorted imports
UP035	12	typing.Dict --> dict
F541	10	f-string without placeholders
UP017	6	timezone.utc --> datetime.UTC
UP041	2	asyncio.TimeoutError --> TimeoutError
```