### PR TITLE
chore: fix Ruff N806 for type factory returns

### DIFF
--- a/tests/test_env_inference.py
+++ b/tests/test_env_inference.py
@@ -4,7 +4,7 @@ from midojo.types import Environment
 
 def test_scalar_fields():
     env_data = {"name": "test", "count": 5, "ratio": 3.14, "active": True}
-    EnvType = infer_environment_type("demo", env_data)
+    EnvType = infer_environment_type("demo", env_data)  # noqa: N806 - type factory
     assert issubclass(EnvType, Environment)
 
     instance = EnvType.model_validate(env_data)
@@ -17,7 +17,7 @@ def test_scalar_fields():
 
 def test_empty_list_defaults():
     env_data = {"items": []}
-    EnvType = infer_environment_type("demo", env_data)
+    EnvType = infer_environment_type("demo", env_data)  # noqa: N806 - type factory
     instance = EnvType.model_validate(env_data)
     assert instance.items == []
 
@@ -32,7 +32,7 @@ def test_dict_of_nested_dicts():
             "SF": {"name": "San Francisco", "pop": 800_000},
         }
     }
-    EnvType = infer_environment_type("demo", env_data)
+    EnvType = infer_environment_type("demo", env_data)  # noqa: N806 - type factory
     instance = EnvType.model_validate(env_data)
     assert instance.cities["NYC"].name == "New York"
     assert instance.cities["SF"].pop == 800_000
@@ -45,7 +45,7 @@ def test_nonempty_list_of_dicts():
             {"city": "NYC", "message": "flood"},
         ]
     }
-    EnvType = infer_environment_type("demo", env_data)
+    EnvType = infer_environment_type("demo", env_data)  # noqa: N806 - type factory
     instance = EnvType.model_validate(env_data)
     assert len(instance.alerts) == 2
     assert instance.alerts[0].city == "Chicago"
@@ -53,7 +53,7 @@ def test_nonempty_list_of_dicts():
 
 def test_nonempty_list_of_scalars():
     env_data = {"tags": ["a", "b", "c"]}
-    EnvType = infer_environment_type("demo", env_data)
+    EnvType = infer_environment_type("demo", env_data)  # noqa: N806 - type factory
     instance = EnvType.model_validate(env_data)
     assert instance.tags == ["a", "b", "c"]
 
@@ -76,7 +76,7 @@ def test_roundtrip_weather_structure():
         },
         "weather_alerts": [],
     }
-    EnvType = infer_environment_type("weather", env_data)
+    EnvType = infer_environment_type("weather", env_data)  # noqa: N806 - type factory
     instance = EnvType.model_validate(env_data)
     assert instance.cities["New York"].temperature_f == 72.0
     assert instance.weather_alerts == []
@@ -90,7 +90,7 @@ def test_roundtrip_weather_structure():
 
 def test_model_copy_deep():
     env_data = {"items": [], "cities": {"A": {"name": "a", "pop": 1}}}
-    EnvType = infer_environment_type("demo", env_data)
+    EnvType = infer_environment_type("demo", env_data)  # noqa: N806 - type factory
     instance = EnvType.model_validate(env_data)
     copy = instance.model_copy(deep=True)
     copy.items.append({"x": 1})


### PR DESCRIPTION
...used in tests.

in preparation of having linting/check on CI,
we need to baseline code to comply with Ruff setup introduced with: https://github.com/asago-ai/midojo/commit/a7d122dd161c11c0b500ade6810fee37c54355c5#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R47

some false positive are introduced in tests failing N806 while intentionally the called fn returns a type

this PR introduce ad-hoc ignore at the false positive site