### PR TITLE
chore: avoid misleading Unicode character

### DIFF
--- a/suites/minibank/real_environment/bank_tools.py
+++ b/suites/minibank/real_environment/bank_tools.py
@@ -53,7 +53,7 @@ def get_tool_definitions() -> List[dict]:
                     "account_id": {"type": "string"},
                     "limit": {
                         "type": "integer",
-                        "description": "Max number of transactions to return (1–20, default 5)",
+                        "description": "Max number of transactions to return (1-20, default 5)",
                     },
                 },
                 "required": ["account_id"],


### PR DESCRIPTION
in preparation of having linting/check on CI,
we need to baseline code to comply with Ruff setup introduced with: https://github.com/asago-ai/midojo/commit/a7d122dd161c11c0b500ade6810fee37c54355c5#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R47

this PR avoid misleading en-dash for regular hyphen to avoid:
- https://docs.astral.sh/ruff/rules/ambiguous-unicode-character-string/#ambiguous-unicode-character-string-ruf001
- warnings in default editor settings:

<img width="446" height="182" alt="image" src="https://github.com/user-attachments/assets/bdad13ab-a878-4928-be75-c50378494f99" />
