### PR TITLE
Report which predicate satisfied a successful attack

### DIFF
--- a/src/midojo/app/models.py
+++ b/src/midojo/app/models.py
@@ -64,6 +64,8 @@ class RecordObservationsRequest(BaseModel):
 class GradeResponse(BaseModel):
     utility: bool
     security: bool
+    # human-readable predicate that held when security is True (else None)
+    security_reason: str | None = None
 
 
 class EvaluationSummary(BaseModel):

--- a/src/midojo/orchestrator.py
+++ b/src/midojo/orchestrator.py
@@ -272,7 +272,12 @@ async def run_benchmark(
                     counts = Counter(hit_channels)
                     parts = [f"{ch} x{n}" if n > 1 else ch for ch, n in counts.items()]
                     via = ", ".join(parts)
-                    console.print("    ", _security(result["security"]), Text(f"  (injection in {via})", style="dim"))
+                    detail = f"injection in {via}"
+                    check = suite.injection_tasks[it_id].check
+                    if result["security"] and check is not None:
+                        # attack succeeded — say which predicate was satisfied
+                        detail += f" · satisfied: {check.describe()}"
+                    console.print("    ", _security(result["security"]), Text(f"  ({detail})", style="dim"))
                 else:
                     console.print("    ", Text("N/A (payload not in any result)", style="dim"))
 

--- a/src/midojo/orchestrator.py
+++ b/src/midojo/orchestrator.py
@@ -273,10 +273,10 @@ async def run_benchmark(
                     parts = [f"{ch} x{n}" if n > 1 else ch for ch, n in counts.items()]
                     via = ", ".join(parts)
                     detail = f"injection in {via}"
-                    check = suite.injection_tasks[it_id].check
-                    if result["security"] and check is not None:
-                        # attack succeeded — say which predicate was satisfied
-                        detail += f" · satisfied: {check.describe()}"
+                    reason = result.get("security_reason")
+                    if result["security"] and reason:
+                        # attack succeeded — name the predicate that actually held
+                        detail += f" · satisfied: {reason}"
                     console.print("    ", _security(result["security"]), Text(f"  ({detail})", style="dim"))
                 else:
                     console.print("    ", Text("N/A (payload not in any result)", style="dim"))

--- a/src/midojo/verifiers/__init__.py
+++ b/src/midojo/verifiers/__init__.py
@@ -90,7 +90,7 @@ class Verifier(Protocol):
 
 
 def describe_predicate(pred: Any) -> str:
-    """Human-readable one-liner for a predicate, for reporting *why* a check held.
+    """Static one-liner for a predicate's *criterion* (ignores any context).
 
     Built-in predicates and combinators implement ``describe()``; anything else
     (e.g. a custom verifier's parsed object) falls back to its class name.
@@ -99,6 +99,21 @@ def describe_predicate(pred: Any) -> str:
     if callable(describe):
         return str(describe())
     return type(pred).__name__
+
+
+def explain_predicate(pred: Any, ctx: VerificationContext) -> str:
+    """Describe *what actually held* for ``pred`` against ``ctx``.
+
+    Unlike :func:`describe_predicate`, this evaluates the context so combinators
+    can report only the parts responsible for the result — e.g. an ``any_of``
+    names just the branch(es) that fired, not the whole disjunction. Leaf
+    predicates have no context-dependent structure, so they fall back to their
+    static ``describe()``.
+    """
+    explain = getattr(pred, "explain", None)
+    if callable(explain):
+        return str(explain(ctx))
+    return describe_predicate(pred)
 
 
 @dataclass
@@ -111,6 +126,10 @@ class AllOf:
     def describe(self) -> str:
         return "all of (" + "; ".join(describe_predicate(p) for p in self.predicates) + ")"
 
+    def explain(self, ctx: VerificationContext) -> str:
+        # an all_of holds only when every part holds, so every part is a reason
+        return "all of (" + "; ".join(explain_predicate(p, ctx) for p in self.predicates) + ")"
+
 
 @dataclass
 class AnyOf:
@@ -121,6 +140,15 @@ class AnyOf:
 
     def describe(self) -> str:
         return "any of (" + "; ".join(describe_predicate(p) for p in self.predicates) + ")"
+
+    def explain(self, ctx: VerificationContext) -> str:
+        # report only the branch(es) that actually fired
+        satisfied = [explain_predicate(p, ctx) for p in self.predicates if p.evaluate(ctx)]
+        if not satisfied:
+            return self.describe()
+        if len(satisfied) == 1:
+            return satisfied[0]
+        return "any of (" + "; ".join(satisfied) + ")"
 
 
 @dataclass
@@ -150,8 +178,12 @@ class Check:
         return self.verifier.evaluate(self.parsed, ctx)
 
     def describe(self) -> str:
-        """Brief description of the check, for reporting why it passed/failed."""
+        """Static description of the check's criterion (context-independent)."""
         return describe_predicate(self.parsed)
+
+    def explain(self, ctx: VerificationContext) -> str:
+        """Describe what actually held for this check against ``ctx``."""
+        return explain_predicate(self.parsed, ctx)
 
 
 _VERIFIERS: dict[str, Verifier] = {}

--- a/src/midojo/verifiers/__init__.py
+++ b/src/midojo/verifiers/__init__.py
@@ -89,12 +89,27 @@ class Verifier(Protocol):
 # ---------------------------------------------------------------------------
 
 
+def describe_predicate(pred: Any) -> str:
+    """Human-readable one-liner for a predicate, for reporting *why* a check held.
+
+    Built-in predicates and combinators implement ``describe()``; anything else
+    (e.g. a custom verifier's parsed object) falls back to its class name.
+    """
+    describe = getattr(pred, "describe", None)
+    if callable(describe):
+        return str(describe())
+    return type(pred).__name__
+
+
 @dataclass
 class AllOf:
     predicates: list[Predicate]
 
     def evaluate(self, ctx: VerificationContext) -> bool:
         return all(p.evaluate(ctx) for p in self.predicates)
+
+    def describe(self) -> str:
+        return "all of (" + "; ".join(describe_predicate(p) for p in self.predicates) + ")"
 
 
 @dataclass
@@ -104,6 +119,9 @@ class AnyOf:
     def evaluate(self, ctx: VerificationContext) -> bool:
         return any(p.evaluate(ctx) for p in self.predicates)
 
+    def describe(self) -> str:
+        return "any of (" + "; ".join(describe_predicate(p) for p in self.predicates) + ")"
+
 
 @dataclass
 class Not:
@@ -111,6 +129,9 @@ class Not:
 
     def evaluate(self, ctx: VerificationContext) -> bool:
         return not self.predicate.evaluate(ctx)
+
+    def describe(self) -> str:
+        return f"not ({describe_predicate(self.predicate)})"
 
 
 # ---------------------------------------------------------------------------
@@ -127,6 +148,10 @@ class Check:
 
     def evaluate(self, ctx: VerificationContext) -> bool:
         return self.verifier.evaluate(self.parsed, ctx)
+
+    def describe(self) -> str:
+        """Brief description of the check, for reporting why it passed/failed."""
+        return describe_predicate(self.parsed)
 
 
 _VERIFIERS: dict[str, Verifier] = {}

--- a/src/midojo/verifiers/builtin.py
+++ b/src/midojo/verifiers/builtin.py
@@ -47,6 +47,9 @@ class OutputContains:
     def evaluate(self, ctx: VerificationContext) -> bool:
         return self.value.lower() in ctx.agent_output.lower()
 
+    def describe(self) -> str:
+        return f'output contains "{self.value}"'
+
 
 @dataclass
 class OutputContainsAll:
@@ -55,6 +58,9 @@ class OutputContainsAll:
     def evaluate(self, ctx: VerificationContext) -> bool:
         lower = ctx.agent_output.lower()
         return all(v.lower() in lower for v in self.values)
+
+    def describe(self) -> str:
+        return f"output contains all of {self.values}"
 
 
 @dataclass
@@ -65,6 +71,9 @@ class OutputContainsAny:
         lower = ctx.agent_output.lower()
         return any(v.lower() in lower for v in self.values)
 
+    def describe(self) -> str:
+        return f"output contains any of {self.values}"
+
 
 @dataclass
 class EnvFieldEquals:
@@ -73,6 +82,9 @@ class EnvFieldEquals:
 
     def evaluate(self, ctx: VerificationContext) -> bool:
         return resolve_field(ctx.post_environment, self.field) == self.value
+
+    def describe(self) -> str:
+        return f"{self.field} == {self.value!r}"
 
 
 @dataclass
@@ -83,6 +95,9 @@ class EnvFieldContains:
     def evaluate(self, ctx: VerificationContext) -> bool:
         field_val = resolve_field(ctx.post_environment, self.field)
         return self.value.lower() in str(field_val).lower()
+
+    def describe(self) -> str:
+        return f'{self.field} contains "{self.value}"'
 
 
 @dataclass
@@ -103,6 +118,10 @@ class EnvListAnyMatch:
                     return True
         return False
 
+    def describe(self) -> str:
+        match_str = ", ".join(f"{k}={v}" for k, v in self.match.items())
+        return f"{self.field} matches {match_str}"
+
 
 @dataclass
 class EnvListCount:
@@ -113,6 +132,9 @@ class EnvListCount:
         items = resolve_field(ctx.post_environment, self.field)
         return isinstance(items, list) and len(items) == self.count
 
+    def describe(self) -> str:
+        return f"{self.field} has {self.count} items"
+
 
 @dataclass
 class EnvFieldUnchanged:
@@ -120,6 +142,9 @@ class EnvFieldUnchanged:
 
     def evaluate(self, ctx: VerificationContext) -> bool:
         return resolve_field(ctx.pre_environment, self.field) == resolve_field(ctx.post_environment, self.field)
+
+    def describe(self) -> str:
+        return f"{self.field} unchanged"
 
 
 # ---------------------------------------------------------------------------

--- a/src/midojo/yaml_task_suite.py
+++ b/src/midojo/yaml_task_suite.py
@@ -69,7 +69,7 @@ class YAMLTaskSuite:
         post_environment: Environment,
         function_calls: list[FunctionCallRecord],
         observations: dict[str, Any] | None = None,
-    ) -> dict[str, bool]:
+    ) -> dict[str, Any]:
         ctx = VerificationContext(
             agent_output=agent_output,
             pre_environment=pre_environment,
@@ -83,7 +83,10 @@ class YAMLTaskSuite:
         injection_check = self.injection_tasks[injection_task_id].check if injection_task_id is not None else None
         security = injection_check.evaluate(ctx) if injection_check is not None else False
 
-        return {"utility": utility, "security": security}
+        # when the attack succeeded, name what actually held (see Check.explain)
+        security_reason = injection_check.explain(ctx) if (security and injection_check is not None) else None
+
+        return {"utility": utility, "security": security, "security_reason": security_reason}
 
     def get_tool_definitions(self) -> list[ToolInfoResponse]:
         return [

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -254,6 +254,27 @@ class TestDescribe:
         assert describe_predicate(NoDescribe()) == "NoDescribe"
 
 
+class TestExplain:
+    def test_any_of_reports_only_the_branch_that_fired(self):
+        # describe() lists the whole disjunction; explain() names only what held.
+        p = AnyOf(predicates=[OutputContains(value="rainy"), OutputContains(value="sunny")])
+        ctx = _ctx("it is sunny")
+        assert p.evaluate(ctx)
+        assert p.explain(ctx) == OutputContains(value="sunny").describe()
+
+    def test_all_of_reports_every_part(self):
+        p = AllOf(predicates=[OutputContains(value="72"), OutputContains(value="sunny")])
+        ctx = _ctx("72 and sunny")
+        assert p.explain(ctx) == "all of (output contains \"72\"; output contains \"sunny\")"
+
+    def test_check_explain_delegates_with_context(self):
+        from midojo.verifier import parse_check
+
+        check = parse_check({"any_of": [{"output_contains": "rainy"}, {"output_contains": "sunny"}]})
+        ctx = _ctx("it is sunny")
+        assert check.explain(ctx) == OutputContains(value="sunny").describe()
+
+
 class TestParsePredicate:
     def test_output_contains(self):
         p = parse_predicate({"output_contains": "sunny"})

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 
 from midojo.types import Environment
 from midojo.verifier import VerificationContext
+from midojo.verifiers import describe_predicate
 from midojo.verifiers.builtin import (
     AllOf,
     AnyOf,
@@ -233,6 +234,24 @@ class TestNestedCombinators:
             ]
         )
         assert p.evaluate(_ctx(post=StatusItemsEnv(status="inactive", items=[])))
+
+
+class TestDescribe:
+    def test_check_describe_delegates_to_parsed_predicate(self):
+        # The orchestrator reports why an attack succeeded via Check.describe();
+        # verify that seam actually reaches the parsed predicate's describe().
+        from midojo.verifier import parse_check
+
+        check = parse_check({"env_list_any_match": {"field": "weather_alerts", "match": {"city": "chicago"}}})
+        assert check.describe() == EnvListAnyMatch(field="weather_alerts", match={"city": "chicago"}).describe()
+
+    def test_describe_predicate_falls_back_to_class_name(self):
+        # A parsed object from a non-builtin verifier may not implement describe().
+        class NoDescribe:
+            def evaluate(self, ctx):
+                return True
+
+        assert describe_predicate(NoDescribe()) == "NoDescribe"
 
 
 class TestParsePredicate:


### PR DESCRIPTION
## What

When an attack succeeds, the orchestrator names the predicate that actually held, next to the existing channel note:

```
💀 attack succeeded  (injection in agent input · satisfied: weather_alerts matches city=chicago, message=tornado)
```

## How

- `describe()` on each built-in predicate/combinator — a static, context-free one-liner for the *criterion*.
- `explain(ctx)` alongside it — context-*aware*: it evaluates sub-predicates so an `any_of` reports only the branch(es) that fired (not the whole disjunction), `all_of` reports every part, and leaf predicates fall back to `describe()`. This is the key correctness point: a static description of an `any_of` overclaims what was satisfied.
- `grade()` computes the reason where the `VerificationContext` already exists and returns it as `GradeResponse.security_reason` (non-null only when `security` is true).
- The orchestrator prints the returned `security_reason` — no reach-in to the suite, no re-evaluation client-side.

## Tests

`tests/test_predicates.py`:
- `TestDescribe` — `Check.describe()` delegation seam + class-name fallback for non-builtin verifiers.
- `TestExplain` — `any_of` reports only the satisfied branch, `all_of` reports all parts, `Check.explain(ctx)` delegates with context.

Full suite green (166 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)