### PR TITLE
feat: Define attack strategy contracts for pluggable libraries

### DIFF
--- a/src/midojo/attacks/__init__.py
+++ b/src/midojo/attacks/__init__.py
@@ -8,6 +8,18 @@ issue #36 for the design.
 
 from __future__ import annotations
 
+from midojo.attacks.protocols import (
+    AttackContext,
+    AttackResult,
+    AttackStrategy,
+    ConversationalAttackStrategy,
+    EvalResult,
+    Injection,
+    IterativeAttackStrategy,
+    PayloadTransform,
+    StaticAttackStrategy,
+    TargetContext,
+)
 from midojo.attacks.records import AttackTechnique, Origin, PayloadSet, PayloadWrapper
 from midojo.attacks.registry import (
     DEFAULT_LIBRARY,
@@ -23,11 +35,21 @@ __all__ = [
     "ASI_DETAILS",
     "DEFAULT_LIBRARY",
     "ASICategory",
+    "AttackContext",
     "AttackLibrary",
+    "AttackResult",
+    "AttackStrategy",
     "AttackTechnique",
+    "ConversationalAttackStrategy",
+    "EvalResult",
+    "Injection",
+    "IterativeAttackStrategy",
     "Origin",
     "PayloadSet",
+    "PayloadTransform",
     "PayloadWrapper",
+    "StaticAttackStrategy",
+    "TargetContext",
     "load_payload_set_file",
     "parse_asi_category",
     "resolve_source",

--- a/src/midojo/attacks/protocols.py
+++ b/src/midojo/attacks/protocols.py
@@ -1,0 +1,169 @@
+"""Attack strategy contracts.
+
+MiDojo defines these protocols so any conforming attack library can be
+plugged in.  The host provides an ``AttackContext``; the library returns
+an ``AttackResult`` via one of three strategy types:
+
+* **Static injection** — single-shot payload via any channel.
+* **Iterative refinement** — payload evolves across attempts (PAIR, TAP,
+  Best-of-N).  Requires attacker LLM config and target context.
+* **Conversational** — exploit unfolds across conversation turns
+  (Crescendo).  Uses ``converse`` to exchange messages with the agent.
+
+Compound strategies (static + conversational) are theoretically possible
+but currently blocked: injection state (tool overrides, output hooks) is
+per-evaluation, so state set in one eval does not persist into a
+subsequent multi-turn eval.  This is noted as a future design concern.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, runtime_checkable
+
+# ---------------------------------------------------------------------------
+# Data protocols — what flows between host and library
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class Injection(Protocol):
+    """What an attack library produces to tell MiDojo what to modify."""
+
+    probes: dict[str, str]
+    prompt_content: str | None
+    prompt_mode: str
+
+
+@runtime_checkable
+class EvalResult(Protocol):
+    """What MiDojo returns after a single evaluation."""
+
+    agent_output: str
+    function_calls: list[dict[str, Any]]
+    security_passed: bool
+    utility_passed: bool
+    security_score: float | None
+    injection: Any
+
+
+@runtime_checkable
+class AttackResult(Protocol):
+    """What the attack library returns after execution."""
+
+    success: bool
+    evaluations: list[Any]
+    strategy_metadata: dict[str, Any]
+
+
+@runtime_checkable
+class PayloadTransform(Protocol):
+    """A payload transformation (wrapper/converter/buff).
+
+    Adapters for external libraries (PyRIT Converters, garak Buffs) can
+    implement this protocol to register their transforms as MiDojo
+    wrappers without wrapping them in ``AttackTechnique``.
+    """
+
+    id: str
+
+    def transform(self, payload: str) -> str: ...
+
+
+# ---------------------------------------------------------------------------
+# Context protocols — what MiDojo provides to the library
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class TargetContext(Protocol):
+    """What the attacker knows about the target agent."""
+
+    tools: list[dict[str, Any]]
+    user_task_prompt: str
+    environment_summary: str
+    system_prompt: str | None
+    dry_run_trace: list[dict[str, Any]] | None
+
+
+@runtime_checkable
+class AttackContext(Protocol):
+    """The execution environment MiDojo provides to attack strategies.
+
+    Two levels of agent interaction:
+
+    * ``evaluate_injection`` — atomic single-shot: set up environment
+      with the injection, send the resulting prompt to the agent, grade,
+      return.  Each call is independent — environment resets between
+      calls.  Used by static and iterative strategies.
+
+    * ``converse`` — send one conversational message to the agent and
+      get a response.  Conversation state is maintained via an opaque
+      token returned alongside the output.  The orchestrator manages
+      the evaluation lifecycle (create / complete / grade) around the
+      strategy execution; the library just talks to the agent.  Used
+      by conversational strategies (Crescendo, social engineering) and
+      external library adapters (PyRIT, garak).  Implementations that
+      do not support conversational strategies should raise
+      ``NotImplementedError``.
+    """
+
+    tool_names: list[str]
+    target: Any
+    attacker_model: str | None
+    attacker_base_url: str | None
+    attacker_api_key: str | None
+
+    async def evaluate_injection(self, injection: Any) -> Any: ...
+
+    async def converse(self, message: str, state: Any) -> tuple[str, Any]: ...
+
+
+# ---------------------------------------------------------------------------
+# Strategy protocols — what the library implements
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class StaticAttackStrategy(Protocol):
+    """Single-shot injection via any channel.
+
+    Calls ``ctx.evaluate_injection`` once with a pre-built injection.
+    """
+
+    id: str
+    strategy_type: Literal["static"]
+
+    async def run(self, spec: Any, ctx: AttackContext) -> AttackResult: ...
+
+
+@runtime_checkable
+class IterativeAttackStrategy(Protocol):
+    """Refines payloads across multiple attempts.
+
+    Calls ``ctx.evaluate_injection`` N times, using an attacker LLM
+    (configured via ``ctx.attacker_model``) and target context
+    (``ctx.target``) to refine payloads between attempts.
+    """
+
+    id: str
+    strategy_type: Literal["iterative"]
+
+    async def run(self, spec: Any, ctx: AttackContext) -> AttackResult: ...
+
+
+@runtime_checkable
+class ConversationalAttackStrategy(Protocol):
+    """Multi-turn conversational exploitation.
+
+    Uses ``ctx.converse`` to exchange messages with the agent across
+    multiple turns, escalating toward the objective.  May combine
+    with static injection in future compound strategies.
+    """
+
+    id: str
+    strategy_type: Literal["conversational"]
+
+    async def run(self, spec: Any, ctx: AttackContext) -> AttackResult: ...
+
+
+AttackStrategy = StaticAttackStrategy | IterativeAttackStrategy | ConversationalAttackStrategy

--- a/tests/test_attack_protocols.py
+++ b/tests/test_attack_protocols.py
@@ -1,0 +1,188 @@
+# ruff: noqa: RUF012
+"""Conformance tests for the attack strategy protocols.
+
+These verify that the Protocol shapes work as intended — toy classes that
+satisfy each protocol pass isinstance checks, and classes missing required
+attributes don't. They do NOT test behavior (no real attack execution).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from midojo.attacks.protocols import (
+    AttackContext,
+    AttackResult,
+    ConversationalAttackStrategy,
+    EvalResult,
+    Injection,
+    IterativeAttackStrategy,
+    PayloadTransform,
+    StaticAttackStrategy,
+    TargetContext,
+)
+
+# ---------------------------------------------------------------------------
+# Toy implementations that satisfy each protocol
+# ---------------------------------------------------------------------------
+
+
+class _ToyInjection:
+    probes: dict[str, str] = {}
+    prompt_content: str | None = None
+    prompt_mode: str = "append"
+
+
+class _ToyEvalResult:
+    agent_output: str = ""
+    function_calls: list[dict[str, Any]] = []
+    security_passed: bool = False
+    utility_passed: bool = True
+    security_score: float | None = None
+    injection: Any = None
+
+
+class _ToyAttackResult:
+    success: bool = False
+    evaluations: list[Any] = []
+    strategy_metadata: dict[str, Any] = {}
+
+
+class _ToyPayloadTransform:
+    id: str = "rot13"
+
+    def transform(self, payload: str) -> str:
+        return payload[::-1]
+
+
+class _ToyTargetContext:
+    tools: list[dict[str, Any]] = []
+    user_task_prompt: str = "What is the weather?"
+    environment_summary: str = "{}"
+    system_prompt: str | None = None
+    dry_run_trace: list[dict[str, Any]] | None = None
+
+
+class _ToyAttackContext:
+    tool_names: list[str] = []
+    target: Any = None
+    attacker_model: str | None = None
+    attacker_base_url: str | None = None
+    attacker_api_key: str | None = None
+
+    async def evaluate_injection(self, injection: Any) -> Any:
+        return _ToyEvalResult()
+
+    async def converse(self, message: str, state: Any) -> tuple[str, Any]:
+        raise NotImplementedError
+
+
+class _ToyStaticStrategy:
+    id: str = "toy-static"
+    strategy_type: str = "static"
+
+    async def run(self, spec: Any, ctx: AttackContext) -> AttackResult:
+        return _ToyAttackResult()
+
+
+class _ToyIterativeStrategy:
+    id: str = "toy-iterative"
+    strategy_type: str = "iterative"
+
+    async def run(self, spec: Any, ctx: AttackContext) -> AttackResult:
+        return _ToyAttackResult()
+
+
+class _ToyConversationalStrategy:
+    id: str = "toy-conversational"
+    strategy_type: str = "conversational"
+
+    async def run(self, spec: Any, ctx: AttackContext) -> AttackResult:
+        return _ToyAttackResult()
+
+
+# ---------------------------------------------------------------------------
+# Data protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestDataProtocols:
+    def test_injection_conforms(self):
+        assert isinstance(_ToyInjection(), Injection)
+
+    def test_eval_result_conforms(self):
+        assert isinstance(_ToyEvalResult(), EvalResult)
+
+    def test_attack_result_conforms(self):
+        assert isinstance(_ToyAttackResult(), AttackResult)
+
+    def test_payload_transform_conforms(self):
+        assert isinstance(_ToyPayloadTransform(), PayloadTransform)
+
+
+# ---------------------------------------------------------------------------
+# Context protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestContextProtocols:
+    def test_target_context_conforms(self):
+        assert isinstance(_ToyTargetContext(), TargetContext)
+
+    def test_attack_context_conforms(self):
+        assert isinstance(_ToyAttackContext(), AttackContext)
+
+    def test_attack_context_requires_methods(self):
+        class _Missing:
+            tool_names: list[str] = []
+            target: Any = None
+            attacker_model: str | None = None
+            attacker_base_url: str | None = None
+            attacker_api_key: str | None = None
+
+        assert not isinstance(_Missing(), AttackContext)
+
+
+# ---------------------------------------------------------------------------
+# Strategy protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestStrategyProtocols:
+    def test_static_strategy_conforms(self):
+        assert isinstance(_ToyStaticStrategy(), StaticAttackStrategy)
+
+    def test_iterative_strategy_conforms(self):
+        assert isinstance(_ToyIterativeStrategy(), IterativeAttackStrategy)
+
+    def test_conversational_strategy_conforms(self):
+        assert isinstance(_ToyConversationalStrategy(), ConversationalAttackStrategy)
+
+    def test_strategy_type_enables_runtime_dispatch(self):
+        """strategy_type lets the orchestrator dispatch without isinstance.
+
+        Literal types are enforced at type-check time (pyright/mypy) but
+        runtime_checkable isinstance only checks attribute existence, not
+        value. The intended dispatch pattern is:
+
+            if strategy.strategy_type == "conversational": ...
+        """
+        assert _ToyStaticStrategy().strategy_type == "static"
+        assert _ToyIterativeStrategy().strategy_type == "iterative"
+        assert _ToyConversationalStrategy().strategy_type == "conversational"
+
+    def test_missing_run_method_fails(self):
+        class _NoRun:
+            id: str = "bad"
+            strategy_type: str = "static"
+
+        assert not isinstance(_NoRun(), StaticAttackStrategy)
+
+    def test_missing_strategy_type_fails(self):
+        class _NoType:
+            id: str = "bad"
+
+            async def run(self, spec: Any, ctx: AttackContext) -> AttackResult:
+                return _ToyAttackResult()
+
+        assert not isinstance(_NoType(), StaticAttackStrategy)


### PR DESCRIPTION
## Summary

Defines the contract between MiDojo (host) and external attack libraries using Python `Protocol` classes. Any library that matches the shapes works without inheriting from MiDojo base classes.

### Strategy taxonomy

Three strategy types, each requiring different host capabilities:

| Strategy | Host callback | Example implementations |
|---|---|---|
| **Static injection** | `evaluate_injection(injection)` — one call | Single-shot payload via any channel |
| **Iterative refinement** | `evaluate_injection` called N times + attacker LLM config + target context | PAIR, TAP, Best-of-N |
| **Conversational** | `converse(message, state) → (output, state)` — per-turn messaging | Crescendo, social engineering |

Each strategy carries a `strategy_type` literal (`"static"`, `"iterative"`, `"conversational"`) for runtime dispatch. An `AttackStrategy` union type is provided for convenience.

### Protocols defined

**Data protocols** (what flows between host and library):
- `Injection` — what the library produces (probes, prompt content)
- `EvalResult` — what MiDojo returns (agent output, function calls, security verdict + optional float score)
- `AttackResult` — what the library returns (success, evaluations, metadata)
- `PayloadTransform` — lightweight wrapper interface for external transforms (PyRIT Converters, garak Buffs)

**Context protocols** (what MiDojo provides):
- `TargetContext` — target agent intelligence (tools, user prompt, environment; system_prompt and dry_run_trace are optional)
- `AttackContext` — execution environment with two interaction levels:
  - `evaluate_injection` — atomic single-shot (static/iterative strategies)
  - `converse` — per-turn messaging for multi-turn attacks and external library adapters. Implementations that don't support conversational strategies raise `NotImplementedError`.

**Strategy protocols** (what the library implements):
- `StaticAttackStrategy`, `IterativeAttackStrategy`, `ConversationalAttackStrategy`
- All share `async def run(spec, ctx) → AttackResult` — distinguished by `strategy_type` literal for runtime dispatch
- `AttackStrategy` — union type of all three

### Design notes

- `evaluate_injection` and `converse` are proper async methods on `AttackContext` (not `Callable` attributes), so implementors write normal Python classes
- `strategy_type` literals are enforced at type-check time (pyright/mypy); runtime dispatch uses `strategy.strategy_type == "conversational"` (Python's `runtime_checkable isinstance` checks attribute existence, not `Literal` values)
- Compound strategies (static + conversational composition) noted as future concern — blocked by per-evaluation injection state
- `spec: Any` on strategy `run()` is intentionally flexible — adapters interpret it as they wish (PyRIT uses `objective: str`, garak uses probe config)

## Test plan

- [x] All MiDojo tests pass (`uv run pytest --ignore=tests/test_mcp_sdk.py` — 165 passed; `test_mcp_sdk` failure is pre-existing missing `fastmcp` dep)
- [x] `ruff check` clean
- [x] 13 protocol conformance tests in `tests/test_attack_protocols.py` covering all data, context, and strategy protocols plus negative cases
- [x] CI passes