### PR TITLE
(refactor) Route control-plane run/eval state through a Store protocol

### DIFF
--- a/src/midojo/app/dependencies.py
+++ b/src/midojo/app/dependencies.py
@@ -42,3 +42,15 @@ def get_current_evaluation(store: Annotated[Store, Depends(get_store)]) -> Evalu
     if evaluation is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No evaluation in progress.")
     return evaluation
+
+
+def get_current_ids(store: Annotated[Store, Depends(get_store)]) -> tuple[str, str]:
+    """(run_id, eval_id) of the active eval, for ID-based mutations on /current.
+
+    Resolves the pointer without fetching the evaluation, so the store does the
+    single lookup during the mutation itself.
+    """
+    ids = store.get_current_ids()
+    if ids is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No evaluation in progress.")
+    return ids

--- a/src/midojo/app/dependencies.py
+++ b/src/midojo/app/dependencies.py
@@ -1,33 +1,44 @@
 from __future__ import annotations
 
-from fastapi import HTTPException, status
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, status
 
 from midojo.yaml_task_suite import YAMLTaskSuite
 
 from . import state
 from .state import Evaluation, Run
+from .store import Store
+
+
+def get_store() -> Store:
+    return state.store
 
 
 def get_suite() -> YAMLTaskSuite:
     return state.suite
 
 
-def get_run(run_id: str) -> Run:
-    run = state.runs.get(run_id)
+def get_run(run_id: str, store: Annotated[Store, Depends(get_store)]) -> Run:
+    run = store.get_run(run_id)
     if run is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Unknown run: {run_id}")
     return run
 
 
-def get_evaluation_by_id(run_id: str, eval_id: str) -> Evaluation:
-    run = get_run(run_id)
-    evaluation = run.evaluations.get(eval_id)
+def get_evaluation_by_id(
+    eval_id: str,
+    run: Annotated[Run, Depends(get_run)],
+    store: Annotated[Store, Depends(get_store)],
+) -> Evaluation:
+    evaluation = store.get_evaluation(run.id, eval_id)
     if evaluation is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Unknown evaluation: {eval_id}")
     return evaluation
 
 
-def get_current_evaluation() -> Evaluation:
-    if state.current_eval is None:
+def get_current_evaluation(store: Annotated[Store, Depends(get_store)]) -> Evaluation:
+    evaluation = store.get_current_evaluation()
+    if evaluation is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No evaluation in progress.")
-    return state.current_eval
+    return evaluation

--- a/src/midojo/app/main.py
+++ b/src/midojo/app/main.py
@@ -6,12 +6,12 @@ from midojo.yaml_task_suite import YAMLTaskSuite
 
 from . import state
 from .routers import runs, suite, tasks, tools
+from .store import InMemoryStore
 
 
 def create_app(suite_instance: YAMLTaskSuite) -> FastAPI:
     state.suite = suite_instance
-    state.runs = {}
-    state.current_eval = None
+    state.store = InMemoryStore()
 
     app = FastAPI()
     app.include_router(suite.router)

--- a/src/midojo/app/routers/runs.py
+++ b/src/midojo/app/routers/runs.py
@@ -9,6 +9,7 @@ from midojo.yaml_task_suite import YAMLTaskSuite
 
 from ..dependencies import (
     get_current_evaluation,
+    get_current_ids,
     get_evaluation_by_id,
     get_run,
     get_store,
@@ -36,6 +37,20 @@ router = APIRouter(prefix="/runs")
 # active eval from the store. Used by long-lived MCP servers / PI extensions that
 # don't have a run/eval ID at construction time. See dependencies.get_current_evaluation.
 current_router = APIRouter(prefix="/current")
+
+
+def _require_eval(evaluation: Evaluation | None, eval_id: str) -> Evaluation:
+    """404 when an ID-based store mutation reports the evaluation doesn't exist."""
+    if evaluation is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Unknown evaluation: {eval_id}")
+    return evaluation
+
+
+def _require_current(evaluation: Evaluation | None) -> Evaluation:
+    """400 when the current-eval pointer no longer resolves to a live evaluation."""
+    if evaluation is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No evaluation in progress.")
+    return evaluation
 
 
 @router.post("", response_model=CreateRunResponse, status_code=status.HTTP_201_CREATED)
@@ -114,11 +129,12 @@ def retrieve_evaluation(evaluation: Annotated[Evaluation, Depends(get_evaluation
 
 @router.post("/{run_id}/evaluations/{eval_id}/complete", status_code=status.HTTP_200_OK)
 def complete_evaluation(
+    eval_id: str,
     req: CompleteRequest,
-    evaluation: Annotated[Evaluation, Depends(get_evaluation_by_id)],
+    run: Annotated[Run, Depends(get_run)],
     store: Annotated[Store, Depends(get_store)],
 ):
-    store.complete_evaluation(evaluation, req.agent_output)
+    _require_eval(store.complete_evaluation(run.id, eval_id, req.agent_output), eval_id)
     return {"status": "completed"}
 
 
@@ -142,7 +158,7 @@ def grade_evaluation(
         function_calls=evaluation.function_calls,
         observations=evaluation.observations,
     )
-    store.set_grade(evaluation, utility=result["utility"], security=result["security"])
+    store.set_grade(evaluation.run_id, evaluation.id, utility=result["utility"], security=result["security"])
     return GradeResponse(**result)
 
 
@@ -165,11 +181,12 @@ def register_environment_update_route(env_type: type) -> None:
     """
 
     def update_environment(
+        eval_id: str,
         body,
-        evaluation: Annotated[Evaluation, Depends(get_evaluation_by_id)],
+        run: Annotated[Run, Depends(get_run)],
         store: Annotated[Store, Depends(get_store)],
     ) -> dict:
-        store.set_environment(evaluation, body)
+        evaluation = _require_eval(store.set_environment(run.id, eval_id, body), eval_id)
         return evaluation.environment.model_dump()
 
     update_environment.__annotations__["body"] = env_type
@@ -177,10 +194,11 @@ def register_environment_update_route(env_type: type) -> None:
 
     def update_current_environment(
         body,
-        evaluation: Annotated[Evaluation, Depends(get_current_evaluation)],
+        ids: Annotated[tuple[str, str], Depends(get_current_ids)],
         store: Annotated[Store, Depends(get_store)],
     ) -> dict:
-        store.set_environment(evaluation, body)
+        run_id, eval_id = ids
+        evaluation = _require_current(store.set_environment(run_id, eval_id, body))
         return evaluation.environment.model_dump()
 
     update_current_environment.__annotations__["body"] = env_type
@@ -216,11 +234,13 @@ def get_function_call(idx: int, evaluation: Annotated[Evaluation, Depends(get_ev
     status_code=status.HTTP_201_CREATED,
 )
 def record_function_call(
+    eval_id: str,
     req: CreateFunctionCallRecord,
-    evaluation: Annotated[Evaluation, Depends(get_evaluation_by_id)],
+    run: Annotated[Run, Depends(get_run)],
     store: Annotated[Store, Depends(get_store)],
 ) -> FunctionCallRecord:
-    return store.append_function_call(evaluation, req)
+    evaluation = _require_eval(store.append_function_call(run.id, eval_id, req), eval_id)
+    return evaluation.function_calls[-1]
 
 
 # --- Observation endpoints ---
@@ -237,11 +257,13 @@ def get_observations(evaluation: Annotated[Evaluation, Depends(get_evaluation_by
 
 @router.post("/{run_id}/evaluations/{eval_id}/observations", status_code=status.HTTP_200_OK)
 def record_observations(
+    eval_id: str,
     req: RecordObservationsRequest,
-    evaluation: Annotated[Evaluation, Depends(get_evaluation_by_id)],
+    run: Annotated[Run, Depends(get_run)],
     store: Annotated[Store, Depends(get_store)],
 ) -> dict:
-    return store.record_observations(evaluation, req.source, req.data)
+    evaluation = _require_eval(store.record_observations(run.id, eval_id, req.source, req.data), eval_id)
+    return evaluation.observations
 
 
 # --- /current mirrors ---
@@ -283,10 +305,12 @@ def get_current_function_call(
 )
 def record_current_function_call(
     req: CreateFunctionCallRecord,
-    evaluation: Annotated[Evaluation, Depends(get_current_evaluation)],
+    ids: Annotated[tuple[str, str], Depends(get_current_ids)],
     store: Annotated[Store, Depends(get_store)],
 ) -> FunctionCallRecord:
-    return store.append_function_call(evaluation, req)
+    run_id, eval_id = ids
+    evaluation = _require_current(store.append_function_call(run_id, eval_id, req))
+    return evaluation.function_calls[-1]
 
 
 @current_router.get("/observations", status_code=status.HTTP_200_OK)
@@ -297,7 +321,9 @@ def get_current_observations(evaluation: Annotated[Evaluation, Depends(get_curre
 @current_router.post("/observations", status_code=status.HTTP_200_OK)
 def record_current_observations(
     req: RecordObservationsRequest,
-    evaluation: Annotated[Evaluation, Depends(get_current_evaluation)],
+    ids: Annotated[tuple[str, str], Depends(get_current_ids)],
     store: Annotated[Store, Depends(get_store)],
 ) -> dict:
-    return store.record_observations(evaluation, req.source, req.data)
+    run_id, eval_id = ids
+    evaluation = _require_current(store.record_observations(run_id, eval_id, req.source, req.data))
+    return evaluation.observations

--- a/src/midojo/app/routers/runs.py
+++ b/src/midojo/app/routers/runs.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -8,8 +7,13 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from midojo.types import FunctionCallRecord
 from midojo.yaml_task_suite import YAMLTaskSuite
 
-from .. import state
-from ..dependencies import get_current_evaluation, get_evaluation_by_id, get_run, get_suite
+from ..dependencies import (
+    get_current_evaluation,
+    get_evaluation_by_id,
+    get_run,
+    get_store,
+    get_suite,
+)
 from ..models import (
     CompleteRequest,
     CreateEvaluationRequest,
@@ -23,20 +27,20 @@ from ..models import (
     RecordObservationsRequest,
     RunResponse,
 )
-from ..state import Evaluation, Run, _new_id
+from ..state import Evaluation, Run
+from ..store import Store
 
 router = APIRouter(prefix="/runs")
 
-# Mirrors of the per-eval environment + function-call endpoints that resolve
-# the active eval from state. Used by long-lived MCP servers / PI extensions
-# that don't have a run/eval ID at construction time. See dependencies.get_current_eval.
+# Mirrors of the per-eval environment + function-call endpoints that resolve the
+# active eval from the store. Used by long-lived MCP servers / PI extensions that
+# don't have a run/eval ID at construction time. See dependencies.get_current_evaluation.
 current_router = APIRouter(prefix="/current")
 
 
 @router.post("", response_model=CreateRunResponse, status_code=status.HTTP_201_CREATED)
-def create_run():
-    run = Run(id=_new_id())
-    state.runs[run.id] = run
+def create_run(store: Annotated[Store, Depends(get_store)]):
+    run = store.create_run()
     return CreateRunResponse(id=run.id)
 
 
@@ -64,6 +68,7 @@ def create_evaluation(
     req: CreateEvaluationRequest,
     run: Annotated[Run, Depends(get_run)],
     suite: Annotated[YAMLTaskSuite, Depends(get_suite)],
+    store: Annotated[Store, Depends(get_store)],
 ):
     if req.user_task_id not in suite.user_tasks:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Unknown user task: {req.user_task_id}")
@@ -74,20 +79,17 @@ def create_evaluation(
 
     environment = suite.provision_environment(req.injections)
     pre_environment = environment.model_copy(deep=True)
+    prompt = suite.inject_user_task_prompt(req.user_task_id, req.injections)
 
-    evaluation = Evaluation(
-        id=_new_id(),
+    evaluation = store.create_evaluation(
+        run.id,
         user_task_id=req.user_task_id,
         injection_task_id=req.injection_task_id,
         pre_environment=pre_environment,
         environment=environment,
         active_injections=req.injections,
+        agent_input=prompt,
     )
-    run.evaluations[evaluation.id] = evaluation
-    state.current_eval = evaluation
-
-    prompt = suite.inject_user_task_prompt(req.user_task_id, req.injections)
-    evaluation.agent_input = prompt
     return CreateEvaluationResponse(id=evaluation.id, prompt=prompt)
 
 
@@ -111,9 +113,12 @@ def retrieve_evaluation(evaluation: Annotated[Evaluation, Depends(get_evaluation
 
 
 @router.post("/{run_id}/evaluations/{eval_id}/complete", status_code=status.HTTP_200_OK)
-def complete_evaluation(req: CompleteRequest, evaluation: Annotated[Evaluation, Depends(get_evaluation_by_id)]):
-    evaluation.agent_output = req.agent_output
-    evaluation.completed = True
+def complete_evaluation(
+    req: CompleteRequest,
+    evaluation: Annotated[Evaluation, Depends(get_evaluation_by_id)],
+    store: Annotated[Store, Depends(get_store)],
+):
+    store.complete_evaluation(evaluation, req.agent_output)
     return {"status": "completed"}
 
 
@@ -121,6 +126,7 @@ def complete_evaluation(req: CompleteRequest, evaluation: Annotated[Evaluation, 
 def grade_evaluation(
     evaluation: Annotated[Evaluation, Depends(get_evaluation_by_id)],
     suite: Annotated[YAMLTaskSuite, Depends(get_suite)],
+    store: Annotated[Store, Depends(get_store)],
 ):
     if not evaluation.completed:
         raise HTTPException(
@@ -136,8 +142,7 @@ def grade_evaluation(
         function_calls=evaluation.function_calls,
         observations=evaluation.observations,
     )
-    evaluation.utility = result["utility"]
-    evaluation.security = result["security"]
+    store.set_grade(evaluation, utility=result["utility"], security=result["security"])
     return GradeResponse(**result)
 
 
@@ -159,15 +164,23 @@ def register_environment_update_route(env_type: type) -> None:
     on the handler to give FastAPI the right body type.
     """
 
-    def update_environment(body, evaluation: Annotated[Evaluation, Depends(get_evaluation_by_id)]) -> dict:
-        evaluation.environment = body
+    def update_environment(
+        body,
+        evaluation: Annotated[Evaluation, Depends(get_evaluation_by_id)],
+        store: Annotated[Store, Depends(get_store)],
+    ) -> dict:
+        store.set_environment(evaluation, body)
         return evaluation.environment.model_dump()
 
     update_environment.__annotations__["body"] = env_type
     router.add_api_route("/{run_id}/evaluations/{eval_id}/environment", update_environment, methods=["PUT"])
 
-    def update_current_environment(body, evaluation: Annotated[Evaluation, Depends(get_current_evaluation)]) -> dict:
-        evaluation.environment = body
+    def update_current_environment(
+        body,
+        evaluation: Annotated[Evaluation, Depends(get_current_evaluation)],
+        store: Annotated[Store, Depends(get_store)],
+    ) -> dict:
+        store.set_environment(evaluation, body)
         return evaluation.environment.model_dump()
 
     update_current_environment.__annotations__["body"] = env_type
@@ -197,21 +210,6 @@ def get_function_call(idx: int, evaluation: Annotated[Evaluation, Depends(get_ev
     return evaluation.function_calls[idx]
 
 
-def _append_function_call(req: CreateFunctionCallRecord, evaluation: Evaluation) -> FunctionCallRecord:
-    if evaluation.function_calls:
-        pre_env = evaluation.function_calls[-1].post_environment
-    else:
-        pre_env = evaluation.pre_environment
-    record = FunctionCallRecord(
-        **req.model_dump(),
-        timestamp=datetime.now(UTC).isoformat(),
-        pre_environment=pre_env,
-        post_environment=evaluation.environment.model_copy(deep=True),
-    )
-    evaluation.function_calls.append(record)
-    return record
-
-
 @router.post(
     "/{run_id}/evaluations/{eval_id}/function-calls",
     response_model=FunctionCallResponse,
@@ -220,8 +218,9 @@ def _append_function_call(req: CreateFunctionCallRecord, evaluation: Evaluation)
 def record_function_call(
     req: CreateFunctionCallRecord,
     evaluation: Annotated[Evaluation, Depends(get_evaluation_by_id)],
+    store: Annotated[Store, Depends(get_store)],
 ) -> FunctionCallRecord:
-    return _append_function_call(req, evaluation)
+    return store.append_function_call(evaluation, req)
 
 
 # --- Observation endpoints ---
@@ -229,11 +228,6 @@ def record_function_call(
 # Runtime evidence streams (e.g. OpenShell OCSF events) the runner reads from a
 # source and records here, keyed by source — symmetric with PUT /environment.
 # Verifiers read them from VerificationContext.observations at grade time.
-
-
-def _record_observations(req: RecordObservationsRequest, evaluation: Evaluation) -> dict:
-    evaluation.observations[req.source] = req.data
-    return evaluation.observations
 
 
 @router.get("/{run_id}/evaluations/{eval_id}/observations", status_code=status.HTTP_200_OK)
@@ -245,8 +239,9 @@ def get_observations(evaluation: Annotated[Evaluation, Depends(get_evaluation_by
 def record_observations(
     req: RecordObservationsRequest,
     evaluation: Annotated[Evaluation, Depends(get_evaluation_by_id)],
+    store: Annotated[Store, Depends(get_store)],
 ) -> dict:
-    return _record_observations(req, evaluation)
+    return store.record_observations(evaluation, req.source, req.data)
 
 
 # --- /current mirrors ---
@@ -289,8 +284,9 @@ def get_current_function_call(
 def record_current_function_call(
     req: CreateFunctionCallRecord,
     evaluation: Annotated[Evaluation, Depends(get_current_evaluation)],
+    store: Annotated[Store, Depends(get_store)],
 ) -> FunctionCallRecord:
-    return _append_function_call(req, evaluation)
+    return store.append_function_call(evaluation, req)
 
 
 @current_router.get("/observations", status_code=status.HTTP_200_OK)
@@ -302,5 +298,6 @@ def get_current_observations(evaluation: Annotated[Evaluation, Depends(get_curre
 def record_current_observations(
     req: RecordObservationsRequest,
     evaluation: Annotated[Evaluation, Depends(get_current_evaluation)],
+    store: Annotated[Store, Depends(get_store)],
 ) -> dict:
-    return _record_observations(req, evaluation)
+    return store.record_observations(evaluation, req.source, req.data)

--- a/src/midojo/app/routers/suite.py
+++ b/src/midojo/app/routers/suite.py
@@ -20,4 +20,3 @@ def suite_info(suite: Annotated[YAMLTaskSuite, Depends(get_suite)]):
         tools=suite.get_tool_names(),
         environment=suite.provision_environment({}),
     )
-

--- a/src/midojo/app/routers/tasks.py
+++ b/src/midojo/app/routers/tasks.py
@@ -44,5 +44,3 @@ def get_injection_task(task_id: str, suite: Annotated[YAMLTaskSuite, Depends(get
         type="injection",
         description=task.description,
     )
-
-

--- a/src/midojo/app/state.py
+++ b/src/midojo/app/state.py
@@ -1,7 +1,9 @@
 """Process-local application state.
 
-Persistence is in-memory only (lost on restart). A db store may replace
-this layer later.
+Run/evaluation state lives behind the :class:`~midojo.app.store.Store` seam
+(see ``store.py``); this module holds only the process-global handles wired up
+at startup — the loaded ``suite`` and the active ``store``. The default store is
+in-memory (lost on restart); a db-backed store may replace it later.
 """
 
 from __future__ import annotations
@@ -9,12 +11,15 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from midojo.types import Environment, FunctionCallRecord
 from midojo.yaml_task_suite import YAMLTaskSuite
+
+if TYPE_CHECKING:
+    from .store import Store
 
 
 def _new_id() -> str:
@@ -55,9 +60,10 @@ class Run(BaseModel):
 
 
 # --- Module-level state ---
+#
+# Set by create_app() at startup. `store` is the seam through which all
+# run/evaluation state is accessed; routers reach it via the get_store
+# dependency rather than touching this module directly.
 
 suite: YAMLTaskSuite = None  # type: ignore[assignment]
-runs: dict[str, Run] = {}
-# Only one eval is active at a time — the orchestrator runs tasks sequentially.
-# Concurrent evals would clobber this; use explicit /runs/{id}/evaluations/{id}/* routes instead.
-current_eval: Evaluation | None = None
+store: Store = None  # type: ignore[assignment]

--- a/src/midojo/app/state.py
+++ b/src/midojo/app/state.py
@@ -34,6 +34,7 @@ class Evaluation:
     """A single task execution within a Run. Captures the environment before and after tool execution, the function call trace, and grading results."""
 
     id: str
+    run_id: str
     user_task_id: str
     injection_task_id: str | None
     pre_environment: Environment

--- a/src/midojo/app/state.py
+++ b/src/midojo/app/state.py
@@ -8,7 +8,6 @@ in-memory (lost on restart); a db-backed store may replace it later.
 
 from __future__ import annotations
 
-import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -20,10 +19,6 @@ from midojo.yaml_task_suite import YAMLTaskSuite
 
 if TYPE_CHECKING:
     from .store import Store
-
-
-def _new_id() -> str:
-    return uuid.uuid4().hex[:8]
 
 
 # --- State models ---

--- a/src/midojo/app/store.py
+++ b/src/midojo/app/store.py
@@ -17,13 +17,18 @@ old module-global ``state.current_eval`` for now.
 
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime
 from typing import Any, Protocol
 
 from midojo.types import Environment, FunctionCallRecord
 
 from .models import CreateFunctionCallRecord
-from .state import Evaluation, Run, _new_id
+from .state import Evaluation, Run
+
+
+def _new_id() -> str:
+    return uuid.uuid4().hex[:8]
 
 
 class Store(Protocol):

--- a/src/midojo/app/store.py
+++ b/src/midojo/app/store.py
@@ -5,6 +5,11 @@ routers never touch process globals directly. :class:`InMemoryStore` is the
 default, process-local implementation (state lost on restart); a Postgres-backed
 store can be dropped in behind the same interface without changing the routers.
 
+Per-evaluation mutations are ID-based (``run_id``, ``eval_id``) so they map
+directly to a future ``UPDATE … WHERE`` without relying on live Python objects.
+Each returns the mutated :class:`Evaluation`, or ``None`` if no such evaluation
+exists; the HTTP layer turns ``None`` into a 404 (a 400 on the ``/current`` routes).
+
 The store also owns identity (id generation) and tracks the single "current"
 evaluation that backs the ``/current`` endpoints — behavior preserved from the
 old module-global ``state.current_eval`` for now.
@@ -43,13 +48,15 @@ class Store(Protocol):
     ) -> Evaluation: ...
     def get_evaluation(self, run_id: str, eval_id: str) -> Evaluation | None: ...
     def get_current_evaluation(self) -> Evaluation | None: ...
+    def get_current_ids(self) -> tuple[str, str] | None: ...
 
-    # --- per-evaluation mutations ---
-    def append_function_call(self, evaluation: Evaluation, req: CreateFunctionCallRecord) -> FunctionCallRecord: ...
-    def set_environment(self, evaluation: Evaluation, environment: Environment) -> None: ...
-    def record_observations(self, evaluation: Evaluation, source: str, data: Any) -> dict[str, Any]: ...
-    def set_grade(self, evaluation: Evaluation, *, utility: bool, security: bool) -> None: ...
-    def complete_evaluation(self, evaluation: Evaluation, agent_output: str) -> None: ...
+    # --- per-evaluation mutations (ID-based) ---
+    # Each returns the mutated evaluation, or None if (run_id, eval_id) is unknown.
+    def append_function_call(self, run_id: str, eval_id: str, req: CreateFunctionCallRecord) -> Evaluation | None: ...
+    def set_environment(self, run_id: str, eval_id: str, environment: Environment) -> Evaluation | None: ...
+    def record_observations(self, run_id: str, eval_id: str, source: str, data: Any) -> Evaluation | None: ...
+    def set_grade(self, run_id: str, eval_id: str, *, utility: bool, security: bool) -> Evaluation | None: ...
+    def complete_evaluation(self, run_id: str, eval_id: str, agent_output: str) -> Evaluation | None: ...
 
 
 class InMemoryStore:
@@ -58,9 +65,10 @@ class InMemoryStore:
     def __init__(self) -> None:
         self._runs: dict[str, Run] = {}
         # Only one eval is active at a time — the orchestrator runs tasks
-        # sequentially. Tracked here to back the /current endpoints; concurrent
-        # evals would clobber it (superseded by session-scoped resolution later).
-        self._current_eval: Evaluation | None = None
+        # sequentially. Tracked as (run_id, eval_id) to back the /current
+        # endpoints; concurrent evals would clobber it (superseded by
+        # session-scoped resolution later).
+        self._current_ids: tuple[str, str] | None = None
 
     # --- runs ---
 
@@ -90,6 +98,7 @@ class InMemoryStore:
     ) -> Evaluation:
         evaluation = Evaluation(
             id=_new_id(),
+            run_id=run_id,
             user_task_id=user_task_id,
             injection_task_id=injection_task_id,
             pre_environment=pre_environment,
@@ -98,7 +107,7 @@ class InMemoryStore:
             agent_input=agent_input,
         )
         self._runs[run_id].evaluations[evaluation.id] = evaluation
-        self._current_eval = evaluation
+        self._current_ids = (run_id, evaluation.id)
         return evaluation
 
     def get_evaluation(self, run_id: str, eval_id: str) -> Evaluation | None:
@@ -108,11 +117,20 @@ class InMemoryStore:
         return run.evaluations.get(eval_id)
 
     def get_current_evaluation(self) -> Evaluation | None:
-        return self._current_eval
+        ids = self.get_current_ids()
+        if ids is None:
+            return None
+        return self.get_evaluation(*ids)
+
+    def get_current_ids(self) -> tuple[str, str] | None:
+        return self._current_ids
 
     # --- per-evaluation mutations ---
 
-    def append_function_call(self, evaluation: Evaluation, req: CreateFunctionCallRecord) -> FunctionCallRecord:
+    def append_function_call(self, run_id: str, eval_id: str, req: CreateFunctionCallRecord) -> Evaluation | None:
+        evaluation = self.get_evaluation(run_id, eval_id)
+        if evaluation is None:
+            return None
         # Each call's pre-env is the previous call's post-env, chaining from the
         # eval's initial environment; post-env is a deep copy so later mutations
         # don't retroactively change the recorded snapshot.
@@ -127,19 +145,34 @@ class InMemoryStore:
             post_environment=evaluation.environment.model_copy(deep=True),
         )
         evaluation.function_calls.append(record)
-        return record
+        return evaluation
 
-    def set_environment(self, evaluation: Evaluation, environment: Environment) -> None:
+    def set_environment(self, run_id: str, eval_id: str, environment: Environment) -> Evaluation | None:
+        evaluation = self.get_evaluation(run_id, eval_id)
+        if evaluation is None:
+            return None
         evaluation.environment = environment
+        return evaluation
 
-    def record_observations(self, evaluation: Evaluation, source: str, data: Any) -> dict[str, Any]:
+    def record_observations(self, run_id: str, eval_id: str, source: str, data: Any) -> Evaluation | None:
+        evaluation = self.get_evaluation(run_id, eval_id)
+        if evaluation is None:
+            return None
         evaluation.observations[source] = data
-        return evaluation.observations
+        return evaluation
 
-    def set_grade(self, evaluation: Evaluation, *, utility: bool, security: bool) -> None:
+    def set_grade(self, run_id: str, eval_id: str, *, utility: bool, security: bool) -> Evaluation | None:
+        evaluation = self.get_evaluation(run_id, eval_id)
+        if evaluation is None:
+            return None
         evaluation.utility = utility
         evaluation.security = security
+        return evaluation
 
-    def complete_evaluation(self, evaluation: Evaluation, agent_output: str) -> None:
+    def complete_evaluation(self, run_id: str, eval_id: str, agent_output: str) -> Evaluation | None:
+        evaluation = self.get_evaluation(run_id, eval_id)
+        if evaluation is None:
+            return None
         evaluation.agent_output = agent_output
         evaluation.completed = True
+        return evaluation

--- a/src/midojo/app/store.py
+++ b/src/midojo/app/store.py
@@ -1,0 +1,145 @@
+"""State persistence seam for the control plane.
+
+All run/evaluation state is accessed through the :class:`Store` protocol so the
+routers never touch process globals directly. :class:`InMemoryStore` is the
+default, process-local implementation (state lost on restart); a Postgres-backed
+store can be dropped in behind the same interface without changing the routers.
+
+The store also owns identity (id generation) and tracks the single "current"
+evaluation that backs the ``/current`` endpoints — behavior preserved from the
+old module-global ``state.current_eval`` for now.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+from midojo.types import Environment, FunctionCallRecord
+
+from .models import CreateFunctionCallRecord
+from .state import Evaluation, Run, _new_id
+
+
+class Store(Protocol):
+    """Interface for run/evaluation persistence."""
+
+    # --- runs ---
+    def create_run(self) -> Run: ...
+    def get_run(self, run_id: str) -> Run | None: ...
+    def list_runs(self) -> list[Run]: ...
+
+    # --- evaluations ---
+    def create_evaluation(
+        self,
+        run_id: str,
+        *,
+        user_task_id: str,
+        injection_task_id: str | None,
+        pre_environment: Environment,
+        environment: Environment,
+        active_injections: dict[str, str],
+        agent_input: str | None = None,
+    ) -> Evaluation: ...
+    def get_evaluation(self, run_id: str, eval_id: str) -> Evaluation | None: ...
+    def get_current_evaluation(self) -> Evaluation | None: ...
+
+    # --- per-evaluation mutations ---
+    def append_function_call(self, evaluation: Evaluation, req: CreateFunctionCallRecord) -> FunctionCallRecord: ...
+    def set_environment(self, evaluation: Evaluation, environment: Environment) -> None: ...
+    def record_observations(self, evaluation: Evaluation, source: str, data: Any) -> dict[str, Any]: ...
+    def set_grade(self, evaluation: Evaluation, *, utility: bool, security: bool) -> None: ...
+    def complete_evaluation(self, evaluation: Evaluation, agent_output: str) -> None: ...
+
+
+class InMemoryStore:
+    """Process-local, in-memory :class:`Store`. State is lost on restart."""
+
+    def __init__(self) -> None:
+        self._runs: dict[str, Run] = {}
+        # Only one eval is active at a time — the orchestrator runs tasks
+        # sequentially. Tracked here to back the /current endpoints; concurrent
+        # evals would clobber it (superseded by session-scoped resolution later).
+        self._current_eval: Evaluation | None = None
+
+    # --- runs ---
+
+    def create_run(self) -> Run:
+        run = Run(id=_new_id())
+        self._runs[run.id] = run
+        return run
+
+    def get_run(self, run_id: str) -> Run | None:
+        return self._runs.get(run_id)
+
+    def list_runs(self) -> list[Run]:
+        return list(self._runs.values())
+
+    # --- evaluations ---
+
+    def create_evaluation(
+        self,
+        run_id: str,
+        *,
+        user_task_id: str,
+        injection_task_id: str | None,
+        pre_environment: Environment,
+        environment: Environment,
+        active_injections: dict[str, str],
+        agent_input: str | None = None,
+    ) -> Evaluation:
+        evaluation = Evaluation(
+            id=_new_id(),
+            user_task_id=user_task_id,
+            injection_task_id=injection_task_id,
+            pre_environment=pre_environment,
+            environment=environment,
+            active_injections=active_injections,
+            agent_input=agent_input,
+        )
+        self._runs[run_id].evaluations[evaluation.id] = evaluation
+        self._current_eval = evaluation
+        return evaluation
+
+    def get_evaluation(self, run_id: str, eval_id: str) -> Evaluation | None:
+        run = self._runs.get(run_id)
+        if run is None:
+            return None
+        return run.evaluations.get(eval_id)
+
+    def get_current_evaluation(self) -> Evaluation | None:
+        return self._current_eval
+
+    # --- per-evaluation mutations ---
+
+    def append_function_call(self, evaluation: Evaluation, req: CreateFunctionCallRecord) -> FunctionCallRecord:
+        # Each call's pre-env is the previous call's post-env, chaining from the
+        # eval's initial environment; post-env is a deep copy so later mutations
+        # don't retroactively change the recorded snapshot.
+        if evaluation.function_calls:
+            pre_env = evaluation.function_calls[-1].post_environment
+        else:
+            pre_env = evaluation.pre_environment
+        record = FunctionCallRecord(
+            **req.model_dump(),
+            timestamp=datetime.now(UTC).isoformat(),
+            pre_environment=pre_env,
+            post_environment=evaluation.environment.model_copy(deep=True),
+        )
+        evaluation.function_calls.append(record)
+        return record
+
+    def set_environment(self, evaluation: Evaluation, environment: Environment) -> None:
+        evaluation.environment = environment
+
+    def record_observations(self, evaluation: Evaluation, source: str, data: Any) -> dict[str, Any]:
+        evaluation.observations[source] = data
+        return evaluation.observations
+
+    def set_grade(self, evaluation: Evaluation, *, utility: bool, security: bool) -> None:
+        evaluation.utility = utility
+        evaluation.security = security
+
+    def complete_evaluation(self, evaluation: Evaluation, agent_output: str) -> None:
+        evaluation.agent_output = agent_output
+        evaluation.completed = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from midojo.app import state
 from midojo.app.routers import runs, tasks, tools
 from midojo.app.routers import suite as suite_router
+from midojo.app.store import InMemoryStore
 from midojo.suites import get_suite
 
 task_suite = get_suite("weather")
@@ -23,8 +24,7 @@ def environment():
 @pytest.fixture()
 def app() -> FastAPI:
     state.suite = task_suite
-    state.runs = {}
-    state.current_eval = None
+    state.store = InMemoryStore()
     application = FastAPI()
     application.include_router(suite_router.router)
     application.include_router(tasks.router)

--- a/tests/test_control_api.py
+++ b/tests/test_control_api.py
@@ -1,6 +1,14 @@
 from fastapi.testclient import TestClient
 
 from midojo.app import state
+from midojo.app.state import Evaluation
+
+
+def _current_eval() -> Evaluation:
+    """The store's active eval, for asserting internal (non-API) server state."""
+    evaluation = state.store.get_current_evaluation()
+    assert evaluation is not None
+    return evaluation
 
 
 def _create_run(client: TestClient) -> str:
@@ -119,7 +127,7 @@ def test_record_function_call_via_post(client):
     assert len(resp.json()) == 1
 
     # ...but they are still captured server-side for grading.
-    recorded = state.current_eval.function_calls[0]
+    recorded = _current_eval().function_calls[0]
     assert recorded.pre_environment is not None
     assert recorded.post_environment is not None
 
@@ -151,7 +159,7 @@ def test_record_function_call_pre_env_chain(client):
         json={"function": "send_weather_alert", "args": {"city": "New York", "message": "Storm warning"}, "result": "ok"},
     )
 
-    calls = state.current_eval.function_calls
+    calls = _current_eval().function_calls
     assert calls[0].pre_environment.model_dump() == initial_env
     assert calls[1].pre_environment == calls[0].post_environment
     assert calls[1].post_environment.model_dump()["weather_alerts"] == [{"city": "New York", "message": "Storm warning"}]
@@ -279,7 +287,7 @@ def test_record_and_get_observations(client):
     assert resp.status_code == 200
 
     assert client.get(f"/runs/{run_id}/evaluations/{eval_id}/observations").json() == {"openshell": events}
-    assert state.current_eval.observations == {"openshell": events}
+    assert _current_eval().observations == {"openshell": events}
 
 
 def test_current_observations_keyed_by_source(client):

--- a/tests/test_control_api.py
+++ b/tests/test_control_api.py
@@ -156,13 +156,19 @@ def test_record_function_call_pre_env_chain(client):
 
     client.post(
         f"/runs/{run_id}/evaluations/{eval_id}/function-calls",
-        json={"function": "send_weather_alert", "args": {"city": "New York", "message": "Storm warning"}, "result": "ok"},
+        json={
+            "function": "send_weather_alert",
+            "args": {"city": "New York", "message": "Storm warning"},
+            "result": "ok",
+        },
     )
 
     calls = _current_eval().function_calls
     assert calls[0].pre_environment.model_dump() == initial_env
     assert calls[1].pre_environment == calls[0].post_environment
-    assert calls[1].post_environment.model_dump()["weather_alerts"] == [{"city": "New York", "message": "Storm warning"}]
+    assert calls[1].post_environment.model_dump()["weather_alerts"] == [
+        {"city": "New York", "message": "Storm warning"}
+    ]
 
 
 # --- /current/* endpoints ---
@@ -192,6 +198,8 @@ def test_current_environment_put(client):
     env["weather_alerts"] = [{"city": "Boston", "message": "blizzard"}]
     resp = client.put("/current/environment", json=env)
     assert resp.status_code == 200
+    # The PUT's own body is built from the mutated Evaluation, not re-fetched.
+    assert resp.json()["weather_alerts"] == [{"city": "Boston", "message": "blizzard"}]
 
     fresh = client.get(f"/runs/{run_id}/evaluations/{eval_id}/environment").json()
     assert fresh["weather_alerts"] == [{"city": "Boston", "message": "blizzard"}]
@@ -285,6 +293,8 @@ def test_record_and_get_observations(client):
         json={"source": "openshell", "data": events},
     )
     assert resp.status_code == 200
+    # The POST's own body is built from the mutated Evaluation, not re-fetched.
+    assert resp.json() == {"openshell": events}
 
     assert client.get(f"/runs/{run_id}/evaluations/{eval_id}/observations").json() == {"openshell": events}
     assert _current_eval().observations == {"openshell": events}
@@ -301,3 +311,50 @@ def test_current_observations_keyed_by_source(client):
         "openshell": ["PROC:LAUNCH curl"],
         "acs": {"processes": ["curl"]},
     }
+
+
+# --- 404s on the nested mutation routes ---
+#
+# The mutation routes depend on get_run (validates the run) and turn a None store
+# return into a 404 via _require_eval. These exercise both not-found branches --
+# unknown eval under a known run, and unknown run -- across every mutation route,
+# so a miswired handler (missing _require_eval, wrong status/detail) is caught.
+
+
+def _mutation_requests(client: TestClient, run_id: str, eval_id: str, env: dict) -> dict:
+    return {
+        "complete": lambda: client.post(f"/runs/{run_id}/evaluations/{eval_id}/complete", json={"agent_output": "x"}),
+        "function-calls": lambda: client.post(
+            f"/runs/{run_id}/evaluations/{eval_id}/function-calls",
+            json={"function": "f", "args": {}, "result": "r"},
+        ),
+        "observations": lambda: client.post(
+            f"/runs/{run_id}/evaluations/{eval_id}/observations",
+            json={"source": "s", "data": []},
+        ),
+        "environment": lambda: client.put(f"/runs/{run_id}/evaluations/{eval_id}/environment", json=env),
+    }
+
+
+def test_nested_mutation_routes_unknown_eval_404(client):
+    """Known run + unknown eval -> 404 'Unknown evaluation' from _require_eval on every mutation route."""
+    run_id = _create_run(client)
+    _create_evaluation(client, run_id)  # a real eval, so a valid env body is available for the PUT
+    env = client.get("/current/environment").json()
+
+    for name, send in _mutation_requests(client, run_id, "BOGUS", env).items():
+        resp = send()
+        assert resp.status_code == 404, name
+        assert resp.json()["detail"] == "Unknown evaluation: BOGUS", name
+
+
+def test_nested_mutation_routes_unknown_run_404(client):
+    """Unknown run -> 404 'Unknown run' from get_run, before the eval check runs."""
+    run_id = _create_run(client)
+    _create_evaluation(client, run_id)
+    env = client.get("/current/environment").json()
+
+    for name, send in _mutation_requests(client, "BOGUS", "E", env).items():
+        resp = send()
+        assert resp.status_code == 404, name
+        assert resp.json()["detail"] == "Unknown run: BOGUS", name

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,176 @@
+"""Unit tests for the in-memory Store implementation (PR1 store seam)."""
+
+from __future__ import annotations
+
+from midojo.app.models import CreateFunctionCallRecord
+from midojo.app.store import InMemoryStore
+from midojo.types import Environment
+
+
+class _Env(Environment):
+    counter: int = 0
+
+
+def _fc(function: str, result: str) -> CreateFunctionCallRecord:
+    return CreateFunctionCallRecord(function=function, args={}, result=result)
+
+
+def _make_eval(
+    store: InMemoryStore,
+    run_id: str,
+    *,
+    environment: Environment | None = None,
+    pre_environment: Environment | None = None,
+    agent_input: str | None = None,
+):
+    return store.create_evaluation(
+        run_id,
+        user_task_id="ut",
+        injection_task_id=None,
+        pre_environment=pre_environment if pre_environment is not None else _Env(),
+        environment=environment if environment is not None else _Env(),
+        active_injections={},
+        agent_input=agent_input,
+    )
+
+
+# --- runs ---
+
+
+def test_create_run_round_trip():
+    store = InMemoryStore()
+    r1 = store.create_run()
+    r2 = store.create_run()
+    # Each run is retrievable by its own id: two creates coexist without clobbering
+    # (if create_run reused an id, get_run(r1.id) would return r2).
+    assert store.get_run(r1.id) is r1
+    assert store.get_run(r2.id) is r2
+
+
+def test_get_run_unknown_returns_none():
+    # None (not a raise) is the contract the dependency layer turns into a 404.
+    store = InMemoryStore()
+    assert store.get_run("nope") is None
+
+
+def test_list_runs():
+    store = InMemoryStore()
+    assert store.list_runs() == []
+    r1 = store.create_run()
+    r2 = store.create_run()
+    assert {r.id for r in store.list_runs()} == {r1.id, r2.id}
+
+
+# --- evaluations ---
+
+
+def test_create_evaluation_stored_under_run_and_current():
+    store = InMemoryStore()
+    run = store.create_run()
+    ev = _make_eval(store, run.id, agent_input="prompt")
+    assert store.get_evaluation(run.id, ev.id) is ev
+    assert store.get_current_evaluation() is ev
+    assert ev.agent_input == "prompt"  # kwarg is plumbed through to the Evaluation
+
+
+def test_get_evaluation_unknown_returns_none():
+    store = InMemoryStore()
+    run = store.create_run()
+    # Two distinct not-found branches: known run/unknown eval, and unknown run.
+    assert store.get_evaluation(run.id, "nope") is None
+    assert store.get_evaluation("nope", "nope") is None
+
+
+def test_get_current_evaluation_none_before_any():
+    # Backs the "No evaluation in progress" 400 before anything is created.
+    store = InMemoryStore()
+    assert store.get_current_evaluation() is None
+
+
+def test_current_evaluation_follows_latest():
+    store = InMemoryStore()
+    run = store.create_run()
+    _make_eval(store, run.id)
+    ev2 = _make_eval(store, run.id)
+    # Creating a second eval switches /current onto it (the eval-switch semantics).
+    assert store.get_current_evaluation() is ev2
+
+
+# --- function calls ---
+
+
+def test_append_function_call_first_call_chains_from_pre_environment():
+    store = InMemoryStore()
+    run = store.create_run()
+    # pre_environment and the live environment differ so the assertion can tell
+    # which one the first call's pre-env is taken from.
+    ev = _make_eval(store, run.id, pre_environment=_Env(counter=7), environment=_Env(counter=9))
+    rec = store.append_function_call(ev, _fc("a", "r0"))
+    assert isinstance(rec.pre_environment, _Env)
+    assert rec.pre_environment.counter == 7  # first call chains from pre_environment, not the live env
+    assert isinstance(rec.post_environment, _Env)
+    assert rec.post_environment.counter == 9
+    assert ev.function_calls == [rec]
+
+
+def test_append_function_call_chains_pre_env_across_environment_change():
+    store = InMemoryStore()
+    run = store.create_run()
+    ev = _make_eval(store, run.id, environment=_Env(counter=0))
+    r0 = store.append_function_call(ev, _fc("a", "r0"))
+    store.set_environment(ev, _Env(counter=1))
+    r1 = store.append_function_call(ev, _fc("b", "r1"))
+    # Second call's pre-env is the first call's post-env...
+    assert r1.pre_environment == r0.post_environment
+    # ...and its post-env reflects the set_environment that happened in between.
+    assert isinstance(r1.post_environment, _Env)
+    assert r1.post_environment.counter == 1
+    assert ev.function_calls == [r0, r1]
+
+
+def test_append_function_call_post_env_is_deep_copy():
+    store = InMemoryStore()
+    run = store.create_run()
+    env = _Env(counter=0)
+    ev = _make_eval(store, run.id, environment=env)
+    rec = store.append_function_call(ev, _fc("a", "r"))
+    env.counter = 99  # mutate the live env in place after recording
+    # The recorded snapshot is a deep copy, so it doesn't track later mutations.
+    assert isinstance(rec.post_environment, _Env)
+    assert rec.post_environment.counter == 0
+
+
+# --- observations / grade / complete ---
+
+
+def test_record_observations_keyed_by_source():
+    store = InMemoryStore()
+    run = store.create_run()
+    ev = _make_eval(store, run.id)
+    obs = store.record_observations(ev, "openshell", ["e1"])
+    assert obs == {"openshell": ["e1"]}
+    store.record_observations(ev, "acs", {"x": 1})
+    assert ev.observations == {"openshell": ["e1"], "acs": {"x": 1}}
+    # A second write to the same source replaces that source's value only.
+    store.record_observations(ev, "openshell", ["e2"])
+    assert ev.observations == {"openshell": ["e2"], "acs": {"x": 1}}
+
+
+def test_set_grade():
+    store = InMemoryStore()
+    run = store.create_run()
+    ev = _make_eval(store, run.id)
+    # Distinct values guard against the two flags being swapped.
+    store.set_grade(ev, utility=True, security=False)
+    assert ev.utility is True
+    assert ev.security is False
+
+
+def test_complete_evaluation():
+    store = InMemoryStore()
+    run = store.create_run()
+    ev = _make_eval(store, run.id)
+    store.complete_evaluation(ev, "final answer")
+    # Completing records both the flag and the agent's final output.
+    assert ev.completed is True
+    assert ev.agent_output == "final answer"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -68,6 +68,7 @@ def test_create_evaluation_stored_under_run_and_current():
     store = InMemoryStore()
     run = store.create_run()
     ev = _make_eval(store, run.id, agent_input="prompt")
+    assert ev.run_id == run.id
     assert store.get_evaluation(run.id, ev.id) is ev
     assert store.get_current_evaluation() is ev
     assert ev.agent_input == "prompt"  # kwarg is plumbed through to the Evaluation
@@ -105,7 +106,8 @@ def test_append_function_call_first_call_chains_from_pre_environment():
     # pre_environment and the live environment differ so the assertion can tell
     # which one the first call's pre-env is taken from.
     ev = _make_eval(store, run.id, pre_environment=_Env(counter=7), environment=_Env(counter=9))
-    rec = store.append_function_call(ev, _fc("a", "r0"))
+    assert store.append_function_call(run.id, ev.id, _fc("a", "r0")) is ev  # returns the mutated eval
+    rec = ev.function_calls[-1]
     assert isinstance(rec.pre_environment, _Env)
     assert rec.pre_environment.counter == 7  # first call chains from pre_environment, not the live env
     assert isinstance(rec.post_environment, _Env)
@@ -117,15 +119,15 @@ def test_append_function_call_chains_pre_env_across_environment_change():
     store = InMemoryStore()
     run = store.create_run()
     ev = _make_eval(store, run.id, environment=_Env(counter=0))
-    r0 = store.append_function_call(ev, _fc("a", "r0"))
-    store.set_environment(ev, _Env(counter=1))
-    r1 = store.append_function_call(ev, _fc("b", "r1"))
+    store.append_function_call(run.id, ev.id, _fc("a", "r0"))
+    store.set_environment(run.id, ev.id, _Env(counter=1))
+    store.append_function_call(run.id, ev.id, _fc("b", "r1"))
+    r0, r1 = ev.function_calls
     # Second call's pre-env is the first call's post-env...
     assert r1.pre_environment == r0.post_environment
     # ...and its post-env reflects the set_environment that happened in between.
     assert isinstance(r1.post_environment, _Env)
     assert r1.post_environment.counter == 1
-    assert ev.function_calls == [r0, r1]
 
 
 def test_append_function_call_post_env_is_deep_copy():
@@ -133,26 +135,37 @@ def test_append_function_call_post_env_is_deep_copy():
     run = store.create_run()
     env = _Env(counter=0)
     ev = _make_eval(store, run.id, environment=env)
-    rec = store.append_function_call(ev, _fc("a", "r"))
+    store.append_function_call(run.id, ev.id, _fc("a", "r"))
+    rec = ev.function_calls[-1]
     env.counter = 99  # mutate the live env in place after recording
     # The recorded snapshot is a deep copy, so it doesn't track later mutations.
     assert isinstance(rec.post_environment, _Env)
     assert rec.post_environment.counter == 0
 
 
-# --- observations / grade / complete ---
+# --- environment / observations / grade / complete ---
+
+
+def test_set_environment_replaces():
+    store = InMemoryStore()
+    run = store.create_run()
+    ev = _make_eval(store, run.id, environment=_Env(counter=1))
+    new_env = _Env(counter=2)
+    # Returns the mutated evaluation; the new env is installed on it.
+    assert store.set_environment(run.id, ev.id, new_env) is ev
+    assert ev.environment is new_env
 
 
 def test_record_observations_keyed_by_source():
     store = InMemoryStore()
     run = store.create_run()
     ev = _make_eval(store, run.id)
-    obs = store.record_observations(ev, "openshell", ["e1"])
-    assert obs == {"openshell": ["e1"]}
-    store.record_observations(ev, "acs", {"x": 1})
+    assert store.record_observations(run.id, ev.id, "openshell", ["e1"]) is ev
+    assert ev.observations == {"openshell": ["e1"]}
+    store.record_observations(run.id, ev.id, "acs", {"x": 1})
     assert ev.observations == {"openshell": ["e1"], "acs": {"x": 1}}
     # A second write to the same source replaces that source's value only.
-    store.record_observations(ev, "openshell", ["e2"])
+    store.record_observations(run.id, ev.id, "openshell", ["e2"])
     assert ev.observations == {"openshell": ["e2"], "acs": {"x": 1}}
 
 
@@ -161,7 +174,7 @@ def test_set_grade():
     run = store.create_run()
     ev = _make_eval(store, run.id)
     # Distinct values guard against the two flags being swapped.
-    store.set_grade(ev, utility=True, security=False)
+    assert store.set_grade(run.id, ev.id, utility=True, security=False) is ev
     assert ev.utility is True
     assert ev.security is False
 
@@ -170,7 +183,7 @@ def test_complete_evaluation():
     store = InMemoryStore()
     run = store.create_run()
     ev = _make_eval(store, run.id)
-    store.complete_evaluation(ev, "final answer")
+    assert store.complete_evaluation(run.id, ev.id, "final answer") is ev
     # Completing records both the flag and the agent's final output.
     assert ev.completed is True
     assert ev.agent_output == "final answer"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+import pytest
+
 from midojo.app.models import CreateFunctionCallRecord
 from midojo.app.store import InMemoryStore
 from midojo.types import Environment
+
+
+@pytest.fixture
+def store() -> InMemoryStore:
+    return InMemoryStore()
 
 
 class _Env(Environment):
@@ -37,8 +44,7 @@ def _make_eval(
 # --- runs ---
 
 
-def test_create_run_round_trip():
-    store = InMemoryStore()
+def test_create_run_round_trip(store):
     r1 = store.create_run()
     r2 = store.create_run()
     # Each run is retrievable by its own id: two creates coexist without clobbering
@@ -47,14 +53,12 @@ def test_create_run_round_trip():
     assert store.get_run(r2.id) is r2
 
 
-def test_get_run_unknown_returns_none():
+def test_get_run_unknown_returns_none(store):
     # None (not a raise) is the contract the dependency layer turns into a 404.
-    store = InMemoryStore()
     assert store.get_run("nope") is None
 
 
-def test_list_runs():
-    store = InMemoryStore()
+def test_list_runs(store):
     assert store.list_runs() == []
     r1 = store.create_run()
     r2 = store.create_run()
@@ -64,8 +68,7 @@ def test_list_runs():
 # --- evaluations ---
 
 
-def test_create_evaluation_stored_under_run_and_current():
-    store = InMemoryStore()
+def test_create_evaluation_stored_under_run_and_current(store):
     run = store.create_run()
     ev = _make_eval(store, run.id, agent_input="prompt")
     assert ev.run_id == run.id
@@ -74,22 +77,19 @@ def test_create_evaluation_stored_under_run_and_current():
     assert ev.agent_input == "prompt"  # kwarg is plumbed through to the Evaluation
 
 
-def test_get_evaluation_unknown_returns_none():
-    store = InMemoryStore()
+def test_get_evaluation_unknown_returns_none(store):
     run = store.create_run()
     # Two distinct not-found branches: known run/unknown eval, and unknown run.
     assert store.get_evaluation(run.id, "nope") is None
     assert store.get_evaluation("nope", "nope") is None
 
 
-def test_get_current_evaluation_none_before_any():
+def test_get_current_evaluation_none_before_any(store):
     # Backs the "No evaluation in progress" 400 before anything is created.
-    store = InMemoryStore()
     assert store.get_current_evaluation() is None
 
 
-def test_current_evaluation_follows_latest():
-    store = InMemoryStore()
+def test_current_evaluation_follows_latest(store):
     run = store.create_run()
     _make_eval(store, run.id)
     ev2 = _make_eval(store, run.id)
@@ -100,8 +100,7 @@ def test_current_evaluation_follows_latest():
 # --- function calls ---
 
 
-def test_append_function_call_first_call_chains_from_pre_environment():
-    store = InMemoryStore()
+def test_append_function_call_first_call_chains_from_pre_environment(store):
     run = store.create_run()
     # pre_environment and the live environment differ so the assertion can tell
     # which one the first call's pre-env is taken from.
@@ -115,8 +114,7 @@ def test_append_function_call_first_call_chains_from_pre_environment():
     assert ev.function_calls == [rec]
 
 
-def test_append_function_call_chains_pre_env_across_environment_change():
-    store = InMemoryStore()
+def test_append_function_call_chains_pre_env_across_environment_change(store):
     run = store.create_run()
     ev = _make_eval(store, run.id, environment=_Env(counter=0))
     store.append_function_call(run.id, ev.id, _fc("a", "r0"))
@@ -130,8 +128,7 @@ def test_append_function_call_chains_pre_env_across_environment_change():
     assert r1.post_environment.counter == 1
 
 
-def test_append_function_call_post_env_is_deep_copy():
-    store = InMemoryStore()
+def test_append_function_call_post_env_is_deep_copy(store):
     run = store.create_run()
     env = _Env(counter=0)
     ev = _make_eval(store, run.id, environment=env)
@@ -146,8 +143,7 @@ def test_append_function_call_post_env_is_deep_copy():
 # --- environment / observations / grade / complete ---
 
 
-def test_set_environment_replaces():
-    store = InMemoryStore()
+def test_set_environment_replaces(store):
     run = store.create_run()
     ev = _make_eval(store, run.id, environment=_Env(counter=1))
     new_env = _Env(counter=2)
@@ -156,8 +152,7 @@ def test_set_environment_replaces():
     assert ev.environment is new_env
 
 
-def test_record_observations_keyed_by_source():
-    store = InMemoryStore()
+def test_record_observations_keyed_by_source(store):
     run = store.create_run()
     ev = _make_eval(store, run.id)
     assert store.record_observations(run.id, ev.id, "openshell", ["e1"]) is ev
@@ -169,8 +164,7 @@ def test_record_observations_keyed_by_source():
     assert ev.observations == {"openshell": ["e2"], "acs": {"x": 1}}
 
 
-def test_set_grade():
-    store = InMemoryStore()
+def test_set_grade(store):
     run = store.create_run()
     ev = _make_eval(store, run.id)
     # Distinct values guard against the two flags being swapped.
@@ -179,8 +173,7 @@ def test_set_grade():
     assert ev.security is False
 
 
-def test_complete_evaluation():
-    store = InMemoryStore()
+def test_complete_evaluation(store):
     run = store.create_run()
     ev = _make_eval(store, run.id)
     assert store.complete_evaluation(run.id, ev.id, "final answer") is ev

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -180,3 +180,30 @@ def test_complete_evaluation(store):
     # Completing records both the flag and the agent's final output.
     assert ev.completed is True
     assert ev.agent_output == "final answer"
+
+
+# --- mutations return None for an unknown (run, eval) ---
+#
+# Every per-eval mutation honors the uniform `Evaluation | None` contract (the
+# HTTP layer turns that None into a 404 / 400). Per-method coverage so the
+# contract stays pinned at each entry point for future Store implementations.
+
+
+def test_append_function_call_unknown_returns_none(store):
+    assert store.append_function_call("nope", "nope", _fc("a", "r")) is None
+
+
+def test_set_environment_unknown_returns_none(store):
+    assert store.set_environment("nope", "nope", _Env()) is None
+
+
+def test_record_observations_unknown_returns_none(store):
+    assert store.record_observations("nope", "nope", "src", []) is None
+
+
+def test_set_grade_unknown_returns_none(store):
+    assert store.set_grade("nope", "nope", utility=True, security=True) is None
+
+
+def test_complete_evaluation_unknown_returns_none(store):
+    assert store.complete_evaluation("nope", "nope", "out") is None


### PR DESCRIPTION
> we need this in preparation for a real database as the store backend for the control plane

## What

Introduces a `Store` protocol as the single seam for all run/evaluation state in the control plane, so routers never touch process globals directly. `InMemoryStore` is the default (process-local, state lost on restart); a Postgres-backed store can be dropped in behind the same interface without changing the routers.

## Why

Today run/eval state lives in module globals. Routing it through one interface (a) makes the persistence backend swappable and (b) gives us a clean, ID-addressable API that maps onto SQL when we're ready for a durable store.

## Key design points

- **ID-based mutations.** Per-eval mutations take `(run_id, eval_id)` instead of a live `Evaluation` object, mapping directly to a future `UPDATE ... WHERE run_id=? AND id=?`. The store owns its objects.
- **Uniform return contract.** Every mutation returns the mutated `Evaluation`, or `None` when `(run_id, eval_id)` is unknown. The HTTP layer converts `None` into a 404 (400 on the `/current` routes) — not-found is signalled by value, not by a raise from deep in the store.
- **Dependencies over redundant lookups.** Nested mutation routes depend on `get_run` only (one non-redundant lookup; granular *"Unknown run"* vs *"Unknown evaluation"* 404s) and drop a load-bearing `assert` that `-O` would strip. `get_current_ids` lets the `/current` routes resolve the active-eval pointer without a second fetch.

## Tests

- Full store-level unit coverage for the new return contract (`tests/test_store.py`), including the `None`-on-unknown branches.
- End-to-end 404 coverage for every nested mutation route — unknown run **and** known-run/unknown-eval — plus assertions on the mutating call's own response body rather than only re-fetching.
- `182 passed`; ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)