### PR TITLE
Extract boolean combinators into verifiers.combinators

### DIFF
--- a/src/midojo/verifiers/__init__.py
+++ b/src/midojo/verifiers/__init__.py
@@ -3,13 +3,15 @@
 A *verifier* defines *how an outcome is checked*. This module is the
 provider-agnostic framework: the :class:`Predicate` protocol (anything that can
 evaluate a :class:`VerificationContext`), the :class:`Verifier` protocol (parses
-YAML into predicates), the :class:`Check` binding, the boolean combinators
-(:class:`AllOf`, :class:`AnyOf`, :class:`Not`), and the registry that dispatches
-a check block to the verifier that owns it.
+YAML into predicates), the :class:`Check` binding, and the registry that
+dispatches a check block to the verifier that owns it.
 
-Concrete predicate types live in :mod:`midojo.verifiers.builtin` (the default
-verifier). Future verifiers (filesystem inspection, ACS runtime checks, etc.)
-add modules here and self-register on import.
+Concrete predicate types live in sibling modules and are re-exported here: the
+boolean combinators (:class:`AllOf`, :class:`AnyOf`, :class:`Not`) in
+:mod:`midojo.verifiers.combinators`, and the built-in checks in
+:mod:`midojo.verifiers.builtin` (the default verifier). Future verifiers
+(filesystem inspection, ACS runtime checks, etc.) add modules here and
+self-register on import.
 
 How dispatch works: a ``utility:`` / ``security:`` block in ``suite.yaml`` is a
 single-key dict. If that key names a registered verifier, the verifier parses
@@ -114,57 +116,6 @@ class Verifier(Protocol):
 
 
 # ---------------------------------------------------------------------------
-# Combinators
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class AllOf:
-    predicates: list[Predicate]
-
-    def assess(self, ctx: VerificationContext) -> VerificationResult:
-        reasons: list[str] = []
-        for p in self.predicates:
-            r = p.assess(ctx)
-            if not r.passed:
-                return VerificationResult(False, r.reason)  # first failing conjunct — same short-circuit as all()
-            reasons.append(r.reason)
-        return VerificationResult(True, "all of (" + "; ".join(reasons) + ")")
-
-    def evaluate(self, ctx: VerificationContext) -> bool:
-        return self.assess(ctx).passed
-
-
-@dataclass
-class AnyOf:
-    predicates: list[Predicate]
-
-    def assess(self, ctx: VerificationContext) -> VerificationResult:
-        reasons: list[str] = []
-        for p in self.predicates:
-            r = p.assess(ctx)
-            if r.passed:
-                return VerificationResult(True, r.reason)  # only the branch that fired — same short-circuit as any()
-            reasons.append(r.reason)
-        return VerificationResult(False, "any of (" + "; ".join(reasons) + ")")
-
-    def evaluate(self, ctx: VerificationContext) -> bool:
-        return self.assess(ctx).passed
-
-
-@dataclass
-class Not:
-    predicate: Predicate
-
-    def assess(self, ctx: VerificationContext) -> VerificationResult:
-        r = self.predicate.assess(ctx)
-        return VerificationResult(not r.passed, f"not ({r.reason})")
-
-    def evaluate(self, ctx: VerificationContext) -> bool:
-        return self.assess(ctx).passed
-
-
-# ---------------------------------------------------------------------------
 # Check binding & registry
 # ---------------------------------------------------------------------------
 
@@ -239,7 +190,22 @@ def parse_check(raw: dict) -> Check:
 
 
 # ---------------------------------------------------------------------------
-# Auto-register built-in verifiers on import
+# Concrete predicates & auto-registration (imported last to avoid import cycles:
+# these modules import the protocols/context/registry defined above)
 # ---------------------------------------------------------------------------
 
 from midojo.verifiers import builtin as _builtin  # noqa: F401  -- registers the default verifier
+from midojo.verifiers.combinators import AllOf, AnyOf, Not  # re-exported for the public API
+
+__all__ = [
+    "AllOf",
+    "AnyOf",
+    "Check",
+    "Not",
+    "Predicate",
+    "VerificationContext",
+    "VerificationResult",
+    "Verifier",
+    "parse_check",
+    "register_verifier",
+]

--- a/src/midojo/verifiers/builtin.py
+++ b/src/midojo/verifiers/builtin.py
@@ -21,7 +21,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from midojo.types import Environment
-from midojo.verifiers import AllOf, AnyOf, Not, Predicate, VerificationContext, VerificationResult, register_verifier
+from midojo.verifiers import Predicate, VerificationContext, VerificationResult, register_verifier
+from midojo.verifiers.combinators import AllOf, AnyOf, Not
 
 
 def resolve_field(env: Environment, path: str) -> Any:

--- a/src/midojo/verifiers/combinators.py
+++ b/src/midojo/verifiers/combinators.py
@@ -1,0 +1,65 @@
+"""Boolean combinators over predicates.
+
+These are concrete :class:`~midojo.verifiers.Predicate` implementations that
+compose other predicates — the logical glue (``all_of``, ``any_of``, ``not``)
+that suites use to build richer checks. They live alongside the built-in
+predicates (:mod:`midojo.verifiers.builtin`) rather than in the framework core,
+and are re-exported from :mod:`midojo.verifiers` for convenience.
+
+Each combinator produces a :class:`~midojo.verifiers.VerificationResult` whose
+``reason`` names only the criterion that decided the verdict — for an
+:class:`AnyOf` the single branch that fired, for an :class:`AllOf` the
+conjunction, for a :class:`Not` the negated reason.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from midojo.verifiers import Predicate, VerificationContext, VerificationResult
+
+
+@dataclass
+class AllOf:
+    predicates: list[Predicate]
+
+    def assess(self, ctx: VerificationContext) -> VerificationResult:
+        reasons: list[str] = []
+        for p in self.predicates:
+            r = p.assess(ctx)
+            if not r.passed:
+                return VerificationResult(False, r.reason)  # first failing conjunct — same short-circuit as all()
+            reasons.append(r.reason)
+        return VerificationResult(True, "all of (" + "; ".join(reasons) + ")")
+
+    def evaluate(self, ctx: VerificationContext) -> bool:
+        return self.assess(ctx).passed
+
+
+@dataclass
+class AnyOf:
+    predicates: list[Predicate]
+
+    def assess(self, ctx: VerificationContext) -> VerificationResult:
+        reasons: list[str] = []
+        for p in self.predicates:
+            r = p.assess(ctx)
+            if r.passed:
+                return VerificationResult(True, r.reason)  # only the branch that fired — same short-circuit as any()
+            reasons.append(r.reason)
+        return VerificationResult(False, "any of (" + "; ".join(reasons) + ")")
+
+    def evaluate(self, ctx: VerificationContext) -> bool:
+        return self.assess(ctx).passed
+
+
+@dataclass
+class Not:
+    predicate: Predicate
+
+    def assess(self, ctx: VerificationContext) -> VerificationResult:
+        r = self.predicate.assess(ctx)
+        return VerificationResult(not r.passed, f"not ({r.reason})")
+
+    def evaluate(self, ctx: VerificationContext) -> bool:
+        return self.assess(ctx).passed


### PR DESCRIPTION
## What

Move the boolean combinators (`AllOf`, `AnyOf`, `Not`) out of `verifiers/__init__.py` into a dedicated `verifiers/combinators.py`.

## Why

`verifiers/__init__.py` mixed three layers: the framework core (protocols, `VerificationContext`/`VerificationResult`, `Check`, registry), concrete predicate implementations (the combinators), and the auto-registration glue. The combinators are concrete `Predicate` implementations — the same kind of thing as the checks in `builtin.py`, which already lives in its own module. Splitting them out leaves `__init__` as "framework + wiring only," which reads more clearly and mirrors the existing structure.

## Details

- New module `midojo/verifiers/combinators.py` holds `AllOf`/`AnyOf`/`Not` (logic unchanged).
- They are re-exported from `midojo.verifiers`, so **the public API is unchanged** (`from midojo.verifiers import AllOf` still works — `verifier.py`, `builtin.py`, and tests rely on it).
- `builtin.py` now imports the combinators directly from `midojo.verifiers.combinators`, keeping import ordering independent of the re-export.
- Added `__all__` to make the package's public surface explicit.
- Updated the module docstring to point at the new location.

## Testing

- `uv run ruff check .`
- `uv run ruff format .`
- `uv run pyright`
- `uv run pytest` — 188 passed