### PR TITLE
feat(pi-sdk): add reportTools for passive tool-result reporting

### DIFF
--- a/pi-sdk/src/index.ts
+++ b/pi-sdk/src/index.ts
@@ -27,6 +27,15 @@ export interface MidojoExtensionConfig {
 	controlPlaneUrl: string;
 	tools?: MidojoToolDef[];
 	hooks?: MidojoToolHook[];
+	/**
+	 * Names of existing tools whose results are reported to the control plane
+	 * verbatim. Unlike `hooks`, a reporter never rewrites the result the agent
+	 * sees — it taps the output, records it, and leaves it untouched. Use this to
+	 * make a tool's result (e.g. a file `read`) visible to midojo's reachability
+	 * check without perturbing the agent. Names already handled by `hooks` are
+	 * skipped so a tool is never recorded twice.
+	 */
+	reportTools?: string[];
 }
 
 class ControlPlaneClient {
@@ -141,6 +150,31 @@ export function createMidojoExtension(config: MidojoExtensionConfig): (pi: Exten
 				return {
 					content: [{ type: "text" as const, text: result }],
 				};
+			});
+		}
+
+		// Passive reporters: record a tool's result to the control plane without
+		// altering it. Skips any name already covered by `hooks` above so a tool
+		// is never recorded twice.
+		const hookedTools = new Set((config.hooks ?? []).map((h) => h.toolName));
+		for (const reportToolName of new Set(config.reportTools ?? [])) {
+			if (hookedTools.has(reportToolName)) continue;
+			pi.on("tool_result", async (event) => {
+				if (event.toolName !== reportToolName) return;
+
+				const result = event.content
+					.filter((c): c is { type: "text"; text: string } => c.type === "text")
+					.map((c) => c.text)
+					.join("\n");
+
+				await client.recordFunctionCall({
+					function: reportToolName,
+					args: event.input,
+					result,
+					error: null,
+				});
+				// No return value: leave the tool result untouched so the agent
+				// sees the real output — this observes, it does not mutate.
 			});
 		}
 	};


### PR DESCRIPTION
> we need this for proper security reporting in the openshell integration

Adds `reportTools` to `createMidojoExtension` in `@midojo/pi-sdk`.

`reportTools` names existing tools whose results should be reported to the control plane **verbatim**. Unlike `hooks`, a reporter records the tool's output and returns nothing, so the agent sees the unmodified result — making a tool's output (e.g. a file `read`) visible to midojo's reachability check without perturbing the agent.

### Why

`hooks` already fires for built-in tools, and it's good when you want to use a replacement (`{ content: [...] }`), ie., simulate a compromised tool. This alternative, `reportTools`, taps the result and leaves it untouched. It's a passthrough with reporting.

### Behavior

- For each name in `reportTools`, registers a `tool_result` listener that flattens the text content, POSTs `{ function, args, result, error: null }` to `/current/function-calls`, and returns nothing (original result preserved).
- Names already handled by `hooks` are skipped, so a tool is never recorded twice.

```ts
createMidojoExtension({
  controlPlaneUrl: process.env.MIDOJO_URL,
  reportTools: ["read"], // record file reads without rewriting them
});
```

### Notes

- Single-file change to `pi-sdk/src/index.ts` (+34). No new imports, no runtime deps; mirrors the existing `hooks` loop's typed APIs.
- Intended to be consumed by the OpenShell backend work in #70 , where seeded-file attacks are only visible to the reachability gate if the agent's `read` shows up on the function-calls channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
