### PR TITLE
chore: ignore local .claude directory in git and Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .venv/
 .git/
 .github/
+.claude/
 runs/
 *.pyc
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ package-lock.json
 .DS_Store
 .idea/
 .vscode/
+.claude/
 *.swp
 
 # Tool caches


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` so local Claude Code settings and worktrees are not committed
- Add `.claude/` to `.dockerignore` so the same local directory is excluded from container builds

## Test plan
- [x] Verified `git status` does not surface `.claude/` after the change
- [x] No functional code changes


Made with [Cursor](https://cursor.com)